### PR TITLE
[Feature/#11] 참여자의 상태 및 참가자수를 리턴하는 기능 추가

### DIFF
--- a/Data/Data/ConnectedUserRepository.swift
+++ b/Data/Data/ConnectedUserRepository.swift
@@ -11,5 +11,44 @@ import Entity
 import P2PSocket
 
 public final class ConnectedUserRepository: ConnectedUserRepositoryInterface {
-    
+    private var cancellables: Set<AnyCancellable> = []
+    private let socketProvider: SocketProvidable
+
+    public let updatedConnectedUser = PassthroughSubject<ConnectedUser, Never>()
+
+    public init(socketProvider: SocketProvidable) {
+        self.socketProvider = socketProvider
+
+        socketProvider.updatedPeer
+            .compactMap({ [weak self] peer in
+                self?.mappingToConnectedUser(peer) })
+            .subscribe(updatedConnectedUser)
+            .store(in: &cancellables)
+    }
+}
+
+// MARK: - Public Methods
+
+public extension ConnectedUserRepository {
+    func fetchConnectedUsers() -> [ConnectedUser] {
+        return socketProvider.connectedPeers()
+            .compactMap({ mappingToConnectedUser($0) })
+    }
+}
+
+// MARK: - Private Methods
+
+private extension ConnectedUserRepository {
+    func mappingToConnectedUser(_ peer: SocketPeer) -> ConnectedUser? {
+        switch peer.state {
+        case .connected:
+            return .init(id: peer.id, state: .connected, name: peer.name)
+        case .disconnected:
+            return .init(id: peer.id, state: .disconnected, name: peer.name)
+        case .connecting:
+            return .init(id: peer.id, state: .connecting, name: peer.name)
+        default:
+            return nil
+        }
+    }
 }

--- a/Data/Data/ConnectedUserRepository.swift
+++ b/Data/Data/ConnectedUserRepository.swift
@@ -1,0 +1,15 @@
+//
+//  ConnectedUserRepository.swift
+//  Data
+//
+//  Created by 이숲 on 11/11/24.
+//
+
+import Combine
+import Interfaces
+import Entity
+import P2PSocket
+
+public final class ConnectedUserRepository: ConnectedUserRepositoryInterface {
+    
+}

--- a/Domain/Entity/ConnectedUser.swift
+++ b/Domain/Entity/ConnectedUser.swift
@@ -1,0 +1,28 @@
+//
+//  ConnectedUser.swift
+//  Domain
+//
+//  Created by 이숲 on 11/11/24.
+//
+
+public struct ConnectedUser: Identifiable {
+    public enum State {
+        case connected
+        case disconnected
+        case connecting
+    }
+
+    public let id: String
+    public let state: State
+    public let name: String
+
+    public init(
+        id: String,
+        state: State,
+        name: String
+    ) {
+        self.id = id
+        self.state = state
+        self.name = name
+    }
+}

--- a/Domain/Interfaces/ConnectedUserUseCaseInterface.swift
+++ b/Domain/Interfaces/ConnectedUserUseCaseInterface.swift
@@ -9,7 +9,7 @@ import Combine
 import Entity
 
 public protocol ConnectedUserUseCaseInterface {
-    var connectedUSer: PassthroughSubject<ConnectedUser, Never> { get }
+    var connectedUser: PassthroughSubject<ConnectedUser, Never> { get }
 
     init(repository: ConnectedUserRepositoryInterface)
 

--- a/Domain/Interfaces/ConnectedUserUseCaseInterface.swift
+++ b/Domain/Interfaces/ConnectedUserUseCaseInterface.swift
@@ -9,5 +9,9 @@ import Combine
 import Entity
 
 public protocol ConnectedUserUseCaseInterface {
+    var connectedUSer: PassthroughSubject<ConnectedUser, Never> { get }
 
+    init(repository: ConnectedUserRepositoryInterface)
+
+    func fetchConnectedUser() -> [ConnectedUser]
 }

--- a/Domain/Interfaces/ConnectedUserUseCaseInterface.swift
+++ b/Domain/Interfaces/ConnectedUserUseCaseInterface.swift
@@ -1,0 +1,13 @@
+//
+//  ConnectedUserUseCaseInterface.swift
+//  Domain
+//
+//  Created by 이숲 on 11/11/24.
+//
+
+import Combine
+import Entity
+
+public protocol ConnectedUserUseCaseInterface {
+
+}

--- a/Domain/Interfaces/RepositoryInterface/ConnectedUserRepositoryInterface.swift
+++ b/Domain/Interfaces/RepositoryInterface/ConnectedUserRepositoryInterface.swift
@@ -10,5 +10,9 @@ import Entity
 import P2PSocket
 
 public protocol ConnectedUserRepositoryInterface {
+    var updatedConnectedUser: PassthroughSubject<ConnectedUser, Never> { get }
 
+    init(socketProvider: SocketProvidable)
+
+    func fetchConnectedUsers() -> [ConnectedUser]
 }

--- a/Domain/Interfaces/RepositoryInterface/ConnectedUserRepositoryInterface.swift
+++ b/Domain/Interfaces/RepositoryInterface/ConnectedUserRepositoryInterface.swift
@@ -1,0 +1,14 @@
+//
+//  ConnectedUserRepositoryInterface.swift
+//  Domain
+//
+//  Created by 이숲 on 11/11/24.
+//
+
+import Combine
+import Entity
+import P2PSocket
+
+public protocol ConnectedUserRepositoryInterface {
+
+}

--- a/Domain/UseCase/ConnectedUserUseCase.swift
+++ b/Domain/UseCase/ConnectedUserUseCase.swift
@@ -1,0 +1,14 @@
+//
+//  ConnectedUserUseCase.swift
+//  Domain
+//
+//  Created by 이숲 on 11/11/24.
+//
+
+import Combine
+import Interfaces
+import Entity
+
+public final class ConnectedUserUseCase: ConnectedUserUseCaseInterface {
+
+}

--- a/Domain/UseCase/ConnectedUserUseCase.swift
+++ b/Domain/UseCase/ConnectedUserUseCase.swift
@@ -10,5 +10,31 @@ import Interfaces
 import Entity
 
 public final class ConnectedUserUseCase: ConnectedUserUseCaseInterface {
+    private var cancellables: Set<AnyCancellable> = []
+    private let repository: ConnectedUserRepositoryInterface
 
+    public let connectedUser = PassthroughSubject<ConnectedUser, Never>()
+
+    public init(repository: ConnectedUserRepositoryInterface) {
+        self.repository = repository
+        bind()
+    }
+}
+
+// MARK: - Public Methods
+
+public extension ConnectedUserUseCase {
+    func fetchConnectedUsers() -> [ConnectedUser] {
+        return repository.fetchConnectedUsers()
+    }
+}
+
+// MARK: - Private Methods
+
+private extension ConnectedUserUseCase {
+    func bind() {
+        repository.updatedConnectedUser
+            .subscribe(connectedUser)
+            .store(in: &cancellables)
+    }
 }


### PR DESCRIPTION
## 관련 이슈

- https://github.com/boostcampwm-2024/iOS09-BeStory/issues/11

## ✅ 완료 및 수정 내역

### 구현 사항
- [x] Socket에 참가한 유저를 리턴
- [x] Socket에 참여자의 상태를 실시간 업데이트

### 종료 조건
- [ ] Socket에 참가한 유저를 패치해오는지.
- [ ] Socket에 참가한 유저의 상태가 변경되었을 때, 잘 감지되는지.

## 🛠️ 테스트 방법

- 아직 테스트 코드가 없습니다.

## 📝 리뷰 노트

BrowsingUser 기능에 대한 Repository, UseCase를 기준으로 구현하였습니다. P2PSocketProvider의 `connectedPeers` 메서드가 정상적으로 작동한다는 가정하에 구현했습니다.

윤회님의 [[Feature/#2] 참여자의 상태를 표시할 수 있는 기능 구현](https://github.com/boostcampwm-2024/iOS09-BeStory/pull/6/files) 를 merge할 수 있도록 일단 테스트 코드 없이 PR을 올립니다.

추후 test code 추가하겠습니다.

## 추가 사항
- browsing에 대한 메서드 및 클래스 네이밍, 그리고 Entity 네이밍이 browsed와 browsing이 섞여서 같이 사용되는데, 현재 네이밍이 맞다면 이에 맞춰 connectedUser가 아닌 ConnectingUser로 수정하겠습니다.
