### PR TITLE
[Feature/#44] 동영상 리스트 UseCase 작성 + 동기화 로직

### DIFF
--- a/App/App/AppDelegate.swift
+++ b/App/App/AppDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Core
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -20,4 +21,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 		// Use this method to select a configuration to create the new scene with.
 		return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
 	}
+    
+    func applicationWillTerminate(_ application: UIApplication) {
+        FileSystemManager.shared.deleteAllFiles()
+    }
 }

--- a/App/App/SceneDelegate.swift
+++ b/App/App/SceneDelegate.swift
@@ -87,6 +87,11 @@ extension SceneDelegate {
                 repository: DIContainer.shared.resolve(type: ConnectedUserRepositoryInterface.self)
             )
         )
+        
+        DIContainer.shared.register(
+            type: VideoUseCaseInterface.self,
+            instance: VideoUseCase(
+                repository: DIContainer.shared.resolve(type: SharingVideoRepositoryInterface.self)))
     }
 
     func registerViewModel() {
@@ -106,7 +111,9 @@ extension SceneDelegate {
 
         DIContainer.shared.register(
             type: MultipeerVideoListViewModel.self,
-            instance: MultipeerVideoListViewModel()
+            instance: MultipeerVideoListViewModel(
+                usecase: DIContainer.shared.resolve(type: VideoUseCaseInterface.self)
+            )
         )
     }
 }

--- a/Core/Utilities/FileSystemManager.swift
+++ b/Core/Utilities/FileSystemManager.swift
@@ -1,5 +1,5 @@
 //
-//  VideoManager.swift
+//  FileSystemManager.swift
 //  Feature
 //
 //  Created by 디해 on 11/15/24.

--- a/Core/Utilities/FileSystemManager.swift
+++ b/Core/Utilities/FileSystemManager.swift
@@ -5,6 +5,7 @@
 //  Created by 디해 on 11/15/24.
 //
 
+import CryptoKit
 import Foundation
 
 public final class FileSystemManager {
@@ -51,5 +52,26 @@ public final class FileSystemManager {
         fileURLs.forEach { url in
             try? fileManager.removeItem(at: url)
         }
+    }
+    
+    public func collectHashes() -> [String: String] {
+        var fileHashes = [String: String]()
+        
+        guard let fileURLs = try? fileManager.contentsOfDirectory(
+            at: folder,
+            includingPropertiesForKeys: nil
+        ) else { return [:] }
+        for fileURL in fileURLs {
+            guard let hash = calculateFileHash(for: fileURL) else { return [:] }
+            fileHashes[fileURL.lastPathComponent] = hash
+        }
+        
+        return fileHashes
+    }
+    
+    private func calculateFileHash(for fileURL: URL) -> String? {
+        guard let fileData = try? Data(contentsOf: fileURL) else { return nil }
+        let hash = SHA256.hash(data: fileData)
+        return hash.compactMap { String(format: "%02x", $0) }.joined()
     }
 }

--- a/Core/Utilities/FileSystemManager.swift
+++ b/Core/Utilities/FileSystemManager.swift
@@ -26,17 +26,11 @@ public final class FileSystemManager {
         }
     }
     
-    public func copyToFileSystem(tempURL: URL) -> URL? {
-        let originalFileName = tempURL.lastPathComponent
-        let destinationURL = folder.appending(path: originalFileName)
-        if !fileManager.fileExists(atPath: destinationURL.path) {
-            try? fileManager.copyItem(at: tempURL, to: destinationURL)
+    public func copyToFileSystem(tempURL: URL, resourceName: String? = nil) -> URL? {
+        var originalFileName = resourceName ?? tempURL.lastPathComponent
+        if !originalFileName.hasSuffix(".mp4") {
+            originalFileName += ".mp4"
         }
-        return destinationURL
-    }
-    
-    public func copyToFileSystemWithName(tempURL: URL, resourceName: String) -> URL? {
-        let originalFileName = resourceName + ".mp4"
         let destinationURL = folder.appending(path: originalFileName)
         if !fileManager.fileExists(atPath: destinationURL.path) {
             try? fileManager.copyItem(at: tempURL, to: destinationURL)

--- a/Core/Utilities/VideoManager.swift
+++ b/Core/Utilities/VideoManager.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-public final class VideoManager {
-    public static let shared = VideoManager()
+public final class FileSystemManager {
+    public static let shared = FileSystemManager()
 
     private let fileManager = FileManager.default
     private let folder: URL
@@ -25,7 +25,7 @@ public final class VideoManager {
         }
     }
     
-    public func copyVideoToFileSystem(tempURL: URL) -> URL? {
+    public func copyToFileSystem(tempURL: URL) -> URL? {
         let originalFileName = tempURL.lastPathComponent
         let destinationURL = folder.appending(path: originalFileName)
         if !fileManager.fileExists(atPath: destinationURL.path) {

--- a/Core/Utilities/VideoManager.swift
+++ b/Core/Utilities/VideoManager.swift
@@ -34,6 +34,15 @@ public final class FileSystemManager {
         return destinationURL
     }
     
+    public func copyToFileSystemWithName(tempURL: URL, resourceName: String) -> URL? {
+        let originalFileName = resourceName + ".mp4"
+        let destinationURL = folder.appending(path: originalFileName)
+        if !fileManager.fileExists(atPath: destinationURL.path) {
+            try? fileManager.copyItem(at: tempURL, to: destinationURL)
+        }
+        return destinationURL
+    }
+    
     public func deleteAllFiles() {
         guard let fileURLs = try? fileManager.contentsOfDirectory(
             at: folder,

--- a/Data/Data.xcodeproj/project.pbxproj
+++ b/Data/Data.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		D9CF36472CF0858200B1A92D /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D9CF36462CF0858200B1A92D /* Core.framework */; };
 		FEF779662CDCB2CF00FFE089 /* Entity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FEF779652CDCB2CF00FFE089 /* Entity.framework */; };
 		FEF779962CDCE10300FFE089 /* Interfaces.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FEF779952CDCE10300FFE089 /* Interfaces.framework */; };
 /* End PBXBuildFile section */
@@ -44,6 +45,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		D9CF36462CF0858200B1A92D /* Core.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FED9682A2CD9094300CD445C /* libData.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libData.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		FED968552CD90FCF00CD445C /* P2PSocket.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = P2PSocket.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FEF779652CDCB2CF00FFE089 /* Entity.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Entity.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -92,6 +94,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D9CF36472CF0858200B1A92D /* Core.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -120,6 +123,7 @@
 		FED967FA2CD9026100CD445C /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				D9CF36462CF0858200B1A92D /* Core.framework */,
 				FEF779952CDCE10300FFE089 /* Interfaces.framework */,
 				FEF779652CDCB2CF00FFE089 /* Entity.framework */,
 			);

--- a/Data/P2PSocket/SocketProvidable.swift
+++ b/Data/P2PSocket/SocketProvidable.swift
@@ -8,7 +8,7 @@
 import Combine
 import Foundation
 
-public protocol SocketProvidable: SocketInvitable, SocketBwrosable, SocketAdvertiseable, SocketResourceSendable { }
+public protocol SocketProvidable: SocketInvitable, SocketBwrosable, SocketAdvertiseable, SocketResourceSendable, HashSynchronizable { }
 
 public protocol SocketAdvertiseable {
 	func startAdvertising()
@@ -45,7 +45,13 @@ public protocol SocketResourceSendable {
 	
 	/// 연결된 모든 Peer들에게 리소스를 전송합니다.
 	@discardableResult
-	func shareResource(url: URL, resourceName: String) async throws -> SharedResource
+    func shareResource(url: URL, resourceName: String) async throws -> SharedResource
 	/// Peer들과 공유한 모든 리소스를 리턴합니다.
 	func sharedAllResources() -> [SharedResource]
+}
+
+public protocol HashSynchronizable {
+    var isSynchronized: PassthroughSubject<Void, Never> { get }
+    
+    func sendHashes(_ hashes: [String: String])
 }

--- a/Data/P2PSocket/SocketProvidable.swift
+++ b/Data/P2PSocket/SocketProvidable.swift
@@ -8,7 +8,9 @@
 import Combine
 import Foundation
 
-public protocol SocketProvidable: SocketInvitable, SocketBwrosable, SocketAdvertiseable, SocketResourceSendable, HashSynchronizable { }
+public protocol SocketProvidable:
+    SocketInvitable, SocketBwrosable, SocketAdvertiseable,
+    SocketResourceSendable, HashSynchronizable { }
 
 public protocol SocketAdvertiseable {
 	func startAdvertising()

--- a/Data/P2PSocket/SocketProvider.swift
+++ b/Data/P2PSocket/SocketProvider.swift
@@ -262,10 +262,10 @@ extension SocketProvider: MCSessionDelegate {
 		at localURL: URL?,
 		withError error: (any Error)?
 	) {
-        let videoManager = FileSystemManager.shared
+        let fileSystemManager = FileSystemManager.shared
         guard let localURL,
               let (resourceName, uuid) = ResourceValidator.extractInformation(name: resourceName),
-              let url = videoManager.copyToFileSystemWithName(
+              let url = fileSystemManager.copyToFileSystemWithName(
                 tempURL: localURL,
                 resourceName: resourceName
               ) else { return }

--- a/Data/P2PSocket/SocketProvider.swift
+++ b/Data/P2PSocket/SocketProvider.swift
@@ -265,10 +265,8 @@ extension SocketProvider: MCSessionDelegate {
         let fileSystemManager = FileSystemManager.shared
         guard let localURL,
               let (resourceName, uuid) = ResourceValidator.extractInformation(name: resourceName),
-              let url = fileSystemManager.copyToFileSystemWithName(
-                tempURL: localURL,
-                resourceName: resourceName
-              ) else { return }
+              let url = fileSystemManager.copyToFileSystem(tempURL: localURL, resourceName: resourceName)
+        else { return }
         
         let resource = SharedResource(
             localUrl: url,

--- a/Data/P2PSocket/SocketProvider.swift
+++ b/Data/P2PSocket/SocketProvider.swift
@@ -221,17 +221,19 @@ extension SocketProvider: MCSessionDelegate {
 		at localURL: URL?,
 		withError error: (any Error)?
 	) {
-        if let localURL,
-            let (resourceName, uuid) = ResourceValidator.extractInformation(name: resourceName) {
-            let resource = SharedResource(
-                localUrl: localURL,
-                name: resourceName,
-                uuid: uuid,
-                sender: peerID.displayName
-            )
-            sharedResources.append(resource)
-            resourceShared.send(resource)
-        }
+        let videoManager = FileSystemManager.shared
+        guard let localURL,
+              let (resourceName, uuid) = ResourceValidator.extractInformation(name: resourceName),
+              let url = videoManager.copyToFileSystemWithName(tempURL: localURL, resourceName: resourceName) else { return }
+        
+        let resource = SharedResource(
+            localUrl: url,
+            name: resourceName,
+            uuid: uuid,
+            sender: peerID.displayName
+        )
+        sharedResources.append(resource)
+        resourceShared.send(resource)
     }
 }
 

--- a/Data/P2PSocket/SocketProvider.swift
+++ b/Data/P2PSocket/SocketProvider.swift
@@ -288,17 +288,16 @@ extension SocketProvider: MCNearbyServiceBrowserDelegate {
 		foundPeer peerID: MCPeerID,
 		withDiscoveryInfo info: [String: String]?
 	) {
-//		if let peer = MCPeerIDStorage.shared.findPeer(for: peerID)?.value {
-//			if peer.state == .pending {
-//				MCPeerIDStorage.shared.update(state: .connected, id: peerID)
-//			}
-//		} else {
-//			MCPeerIDStorage.shared.append(id: peerID, state: .found)
-//		}
-//		
-//		guard let peer = mapToSocketPeer(peerID) else { return }
-//		updatedPeer.send(peer)
-        browser.invitePeer(peerID, to: session, withContext: nil, timeout: 10)
+		if let peer = MCPeerIDStorage.shared.findPeer(for: peerID)?.value {
+			if peer.state == .pending {
+				MCPeerIDStorage.shared.update(state: .connected, id: peerID)
+			}
+		} else {
+			MCPeerIDStorage.shared.append(id: peerID, state: .found)
+		}
+		
+		guard let peer = mapToSocketPeer(peerID) else { return }
+		updatedPeer.send(peer)
 	}
 	
 	public func browser(_ browser: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {
@@ -327,14 +326,13 @@ extension SocketProvider: MCNearbyServiceAdvertiserDelegate {
 		withContext context: Data?,
 		invitationHandler: @escaping (Bool, MCSession?) -> Void
 	) {
-//		guard
-//			isAllowedInvitation,
-//			let invitationPeer = mapToSocketPeer(peerID)
-//		else { return invitationHandler(false, session) }
-//		
-//		invitationReceived.send(invitationPeer)
-//		self.invitationHandler = invitationHandler
-        invitationHandler(true, session)
+		guard
+			isAllowedInvitation,
+			let invitationPeer = mapToSocketPeer(peerID)
+		else { return invitationHandler(false, session) }
+		
+		invitationReceived.send(invitationPeer)
+		self.invitationHandler = invitationHandler
 	}
 }
 

--- a/Data/P2PSocket/SocketProvider.swift
+++ b/Data/P2PSocket/SocketProvider.swift
@@ -185,7 +185,7 @@ extension SocketProvider: MCSessionDelegate {
 		peer peerID: MCPeerID,
 		didChange state: MCSessionState
 	) {
-		guard var socketPeer = mapToSocketPeer(peerID) else { return }
+        guard let socketPeer = mapToSocketPeer(peerID) else { return }
 		var willRemovedAtStorage: Bool = false
 
 		switch state {
@@ -265,7 +265,10 @@ extension SocketProvider: MCSessionDelegate {
         let videoManager = FileSystemManager.shared
         guard let localURL,
               let (resourceName, uuid) = ResourceValidator.extractInformation(name: resourceName),
-              let url = videoManager.copyToFileSystemWithName(tempURL: localURL, resourceName: resourceName) else { return }
+              let url = videoManager.copyToFileSystemWithName(
+                tempURL: localURL,
+                resourceName: resourceName
+              ) else { return }
         
         let resource = SharedResource(
             localUrl: url,

--- a/Domain/Domain.xcodeproj/project.pbxproj
+++ b/Domain/Domain.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 			membershipExceptions = (
 				BrowsingUserUseCase.swift,
 				ConnectedUserUseCase.swift,
+				VideoUseCase.swift,
 			);
 			target = FE6EF3C62CD8B5CA005DC39D /* UseCase */;
 		};

--- a/Domain/Interfaces/RepositoryInterface/SharingVideoRepositoryInterface.swift
+++ b/Domain/Interfaces/RepositoryInterface/SharingVideoRepositoryInterface.swift
@@ -11,7 +11,9 @@ import Foundation
 
 public protocol SharingVideoRepositoryInterface {
     var updatedSharedVideo: PassthroughSubject<SharedVideo, Never> { get }
+    var isSynchronized: PassthroughSubject<Void, Never> { get }
 
     func shareVideo(url: URL, resourceName: String) async throws
     func fetchVideos() -> [SharedVideo]
+    func synchronizeVideos()
 }

--- a/Domain/Interfaces/UseCaseInterface/VideoUseCaseInterface.swift
+++ b/Domain/Interfaces/UseCaseInterface/VideoUseCaseInterface.swift
@@ -1,0 +1,19 @@
+//
+//  VideoUseCaseInterface.swift
+//  Interfaces
+//
+//  Created by 디해 on 11/21/24.
+//
+
+import Combine
+import Entity
+import Foundation
+
+public protocol VideoUseCaseInterface {
+    var updatedVideo: PassthroughSubject<SharedVideo, Never> { get }
+    
+    init(repository: SharingVideoRepositoryInterface)
+    
+    func fetchVideos() -> [SharedVideo]
+    func shareVideo(_ url: URL, resourceName: String)
+}

--- a/Domain/Interfaces/UseCaseInterface/VideoUseCaseInterface.swift
+++ b/Domain/Interfaces/UseCaseInterface/VideoUseCaseInterface.swift
@@ -11,9 +11,11 @@ import Foundation
 
 public protocol VideoUseCaseInterface {
     var updatedVideo: PassthroughSubject<SharedVideo, Never> { get }
+    var isSynchronized: PassthroughSubject<Void, Never> { get }
     
     init(repository: SharingVideoRepositoryInterface)
     
     func fetchVideos() -> [SharedVideo]
     func shareVideo(_ url: URL, resourceName: String)
+    func synchronizeVideos()
 }

--- a/Domain/UseCase/ConnectedUserUseCase.swift
+++ b/Domain/UseCase/ConnectedUserUseCase.swift
@@ -35,7 +35,7 @@ public extension ConnectedUserUseCase {
 private extension ConnectedUserUseCase {
 	func bind() {
 		repository.updatedConnectedUser
-			.sink  { [weak self] user in
+			.sink { [weak self] user in
 				self?.receivedUpdatedState(user: user)
 			}
 			.store(in: &cancellables)
@@ -52,7 +52,6 @@ private extension ConnectedUserUseCase {
 				guard let index = connectedUsersID.firstIndex(where: { $0 == user.id }) else { return }
 				connectedUsersID.remove(at: index)
 				updatedConnectedUser.send(user)
-			default: break
 		}
 	}
 }

--- a/Domain/UseCase/VideoUseCase.swift
+++ b/Domain/UseCase/VideoUseCase.swift
@@ -16,6 +16,7 @@ public final class VideoUseCase: VideoUseCaseInterface {
     private let repository: SharingVideoRepositoryInterface
     
     public let updatedVideo = PassthroughSubject<SharedVideo, Never>()
+    public let isSynchronized = PassthroughSubject<Void, Never>()
     
     public init(repository: SharingVideoRepositoryInterface) {
         self.repository = repository
@@ -36,6 +37,10 @@ public extension VideoUseCase {
             try? await repository.shareVideo(url: url, resourceName: resourceName)
         }
     }
+    
+    func synchronizeVideos() {
+        repository.synchronizeVideos()
+    }
 }
 
 // MARK: - Private Methods
@@ -43,6 +48,9 @@ private extension VideoUseCase {
     func bind() {
         repository.updatedSharedVideo
             .subscribe(updatedVideo)
+            .store(in: &cancellables)
+        repository.isSynchronized
+            .subscribe(isSynchronized)
             .store(in: &cancellables)
     }
 }

--- a/Domain/UseCase/VideoUseCase.swift
+++ b/Domain/UseCase/VideoUseCase.swift
@@ -1,0 +1,48 @@
+//
+//  VideoUseCase.swift
+//  UseCase
+//
+//  Created by 디해 on 11/21/24.
+//
+
+import Combine
+import Entity
+import Foundation
+import Interfaces
+
+public final class VideoUseCase: VideoUseCaseInterface {
+    private var cancellables: Set<AnyCancellable> = []
+    private var sharedVideos: [SharedVideo] = []
+    private let repository: SharingVideoRepositoryInterface
+    
+    public let updatedVideo = PassthroughSubject<SharedVideo, Never>()
+    
+    public init(repository: SharingVideoRepositoryInterface) {
+        self.repository = repository
+        bind()
+    }
+}
+
+// MARK: - Public Methods
+public extension VideoUseCase {
+    func fetchVideos() -> [SharedVideo] {
+        let sharedVideos = repository.fetchVideos()
+        self.sharedVideos = sharedVideos
+        return sharedVideos
+    }
+    
+    func shareVideo(_ url: URL, resourceName: String) {
+        Task {
+            try? await repository.shareVideo(url: url, resourceName: resourceName)
+        }
+    }
+}
+
+// MARK: - Private Methods
+private extension VideoUseCase {
+    func bind() {
+        repository.updatedSharedVideo
+            .subscribe(updatedVideo)
+            .store(in: &cancellables)
+    }
+}

--- a/Feature/Feature.xcodeproj/project.pbxproj
+++ b/Feature/Feature.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 				Helper/EventPublisher.swift,
 				"Helper/UIAlertController+Types.swift",
 				"Helper/UIColor+HexInitialization.swift",
+				VideoListView/TempViewController.swift,
 				MainViewController.swift,
 				VideoListView/VideoDetailView/VideoDetailViewController.swift,
 				VideoListView/VideoListViewController.swift,

--- a/Feature/Feature/VideoListView/TempViewController.swift
+++ b/Feature/Feature/VideoListView/TempViewController.swift
@@ -1,0 +1,18 @@
+//
+//  TempViewController.swift
+//  Feature
+//
+//  Created by 디해 on 11/22/24.
+//
+
+import UIKit
+
+/// 편집 화면으로 이동하기 위한 임시 뷰 컨트롤러 입니다.
+/// 추후 이 뷰 컨트롤러를 사용하여 편집 화면 뷰 컨트롤러를 구현해도 되고, 새로 구현하셔도 됩니다.
+final class TempViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        view.backgroundColor = .blue
+    }
+}

--- a/Feature/Feature/VideoListView/VideoListViewController.swift
+++ b/Feature/Feature/VideoListView/VideoListViewController.swift
@@ -14,7 +14,7 @@ public final class VideoListViewController: UIViewController {
     private let viewModel: any VideoListViewModel
     private let input = PassthroughSubject<VideoListViewInput, Never>()
     private var cancellables = Set<AnyCancellable>()
-    private let videoManager = VideoManager.shared
+    private let videoManager = FileSystemManager.shared
     
     // MARK: - UI Components
     private let headerView = VideoListHeaderView()
@@ -203,7 +203,7 @@ extension VideoListViewController: PHPickerViewControllerDelegate {
         
         itemProvider.loadFileRepresentation(forTypeIdentifier: UTType.movie.identifier) { [weak self] tempURL, error in
             guard let tempURL, error == nil,
-                  let url = self?.videoManager.copyVideoToFileSystem(tempURL: tempURL) else { return }
+                  let url = self?.videoManager.copyToFileSystem(tempURL: tempURL) else { return }
             self?.input.send(.appendVideo(url: url))
         }
     }

--- a/Feature/Feature/VideoListView/VideoListViewController.swift
+++ b/Feature/Feature/VideoListView/VideoListViewController.swift
@@ -19,6 +19,7 @@ public final class VideoListViewController: UIViewController {
     // MARK: - UI Components
     private let headerView = VideoListHeaderView()
     private var collectionView: UICollectionView!
+    private let nextButton = UIButton()
     private var dataSource: VideoListDataSource!
     private let spacing: CGFloat = 20
     
@@ -48,6 +49,7 @@ public final class VideoListViewController: UIViewController {
         setupViewHierarchies()
         setupViewConstraints()
         setupViewBinding()
+        setupNextButton()
         
         input.send(.viewDidLoad)
     }
@@ -65,6 +67,7 @@ private extension VideoListViewController {
     func setupViewHierarchies() {
         view.addSubview(headerView)
         view.addSubview(collectionView)
+        view.addSubview(nextButton)
     }
     
     func setupViewConstraints() {
@@ -78,6 +81,13 @@ private extension VideoListViewController {
             make.horizontalEdges.equalToSuperview().inset(20)
             make.bottom.equalToSuperview()
         }
+        
+        nextButton.snp.makeConstraints { make in
+            make.width.equalTo(160)
+            make.height.equalTo(50)
+            make.centerX.equalToSuperview()
+            make.bottom.equalToSuperview().offset(-50)
+        }
     }
     
     func setupViewBinding() {
@@ -89,6 +99,8 @@ private extension VideoListViewController {
                 switch output {
                 case .videoListDidChanged(let videos):
                     self?.items = videos
+                case .readyForNextScreen:
+                    self?.navigateToEditor()
                 }
             }
             .store(in: &cancellables)
@@ -99,6 +111,20 @@ private extension VideoListViewController {
                 self?.openVideoPicker()
             }
             .store(in: &cancellables)
+        
+        nextButton.publisher(for: .touchUpInside)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.input.send(.validateSynchronization)
+            }
+            .store(in: &cancellables)
+    }
+    
+    func setupNextButton() {
+        nextButton.backgroundColor = .white
+        nextButton.layer.cornerRadius = 25
+        nextButton.setTitle("편집하기", for: .normal)
+        nextButton.setTitleColor(.black, for: .normal)
     }
     
     func setupCollectionView() {
@@ -159,6 +185,11 @@ private extension VideoListViewController {
         let picker = PHPickerViewController(configuration: configuration)
         picker.delegate = self
         present(picker, animated: true, completion: nil)
+    }
+    
+    func navigateToEditor() {
+        let tempViewController = TempViewController(nibName: nil, bundle: nil)
+        navigationController?.pushViewController(tempViewController, animated: true)
     }
 }
 

--- a/Feature/Feature/VideoListView/VideoListViewController.swift
+++ b/Feature/Feature/VideoListView/VideoListViewController.swift
@@ -14,7 +14,7 @@ public final class VideoListViewController: UIViewController {
     private let viewModel: any VideoListViewModel
     private let input = PassthroughSubject<VideoListViewInput, Never>()
     private var cancellables = Set<AnyCancellable>()
-    private let videoManager = FileSystemManager.shared
+    private let fileSystemManager = FileSystemManager.shared
     
     // MARK: - UI Components
     private let headerView = VideoListHeaderView()
@@ -234,7 +234,7 @@ extension VideoListViewController: PHPickerViewControllerDelegate {
         
         itemProvider.loadFileRepresentation(forTypeIdentifier: UTType.movie.identifier) { [weak self] tempURL, error in
             guard let tempURL, error == nil,
-                  let url = self?.videoManager.copyToFileSystem(tempURL: tempURL) else { return }
+                  let url = self?.fileSystemManager.copyToFileSystem(tempURL: tempURL) else { return }
             self?.input.send(.appendVideo(url: url))
         }
     }

--- a/Feature/Feature/VideoListView/ViewModel/MockVideoListViewModel.swift
+++ b/Feature/Feature/VideoListView/ViewModel/MockVideoListViewModel.swift
@@ -25,13 +25,7 @@ public final class MockVideoListViewModel {
 }
 
 private extension MockVideoListViewModel {
-    func setupBind() {
-        usecase.updatedVideo
-            .sink { [weak self] updatedVideo in
-                guard let self else { return }
-            }
-            .store(in: &cancellables)
-    }
+    func setupBind() { }
 }
 
 extension MockVideoListViewModel: VideoListViewModel {

--- a/Feature/Feature/VideoListView/ViewModel/MockVideoListViewModel.swift
+++ b/Feature/Feature/VideoListView/ViewModel/MockVideoListViewModel.swift
@@ -7,15 +7,31 @@
 
 import AVFoundation
 import Combine
+import Entity
+import Interfaces
 
 /// 비디오 리스트를 테스트하기 위한 Mock View Model
 public final class MockVideoListViewModel {
     private var videoItems: [VideoListItem] = []
+    private let usecase: VideoUseCaseInterface
     
     var output = PassthroughSubject<Output, Never>()
     var cancellables: Set<AnyCancellable> = []
     
-    public init() { }
+    public init(usecase: VideoUseCaseInterface) {
+        self.usecase = usecase
+        setupBind()
+    }
+}
+
+private extension MockVideoListViewModel {
+    func setupBind() {
+        usecase.updatedVideo
+            .sink { [weak self] updatedVideo in
+                guard let self else { return }
+            }
+            .store(in: &cancellables)
+    }
 }
 
 extension MockVideoListViewModel: VideoListViewModel {

--- a/Feature/Feature/VideoListView/ViewModel/MockVideoListViewModel.swift
+++ b/Feature/Feature/VideoListView/ViewModel/MockVideoListViewModel.swift
@@ -48,6 +48,8 @@ extension MockVideoListViewModel: VideoListViewModel {
                 Task {
                     await self.appendItem(with: url)
                 }
+            case .validateSynchronization:
+                output.send(.readyForNextScreen)
             }
         }
         .store(in: &cancellables)

--- a/Feature/Feature/VideoListView/ViewModel/MultipeerVideoListViewModel.swift
+++ b/Feature/Feature/VideoListView/ViewModel/MultipeerVideoListViewModel.swift
@@ -35,6 +35,13 @@ private extension MultipeerVideoListViewModel {
                 }
             }
             .store(in: &cancellables)
+        
+        usecase.isSynchronized
+            .sink { [weak self] _ in
+                guard let self else { return }
+                output.send(.readyForNextScreen)
+            }
+            .store(in: &cancellables)
     }
 }
 
@@ -49,6 +56,9 @@ extension MultipeerVideoListViewModel: VideoListViewModel {
                 Task {
                     await self.shareItem(with: url)
                 }
+            case .validateSynchronization:
+                Task {
+                    self.usecase.synchronizeVideos()
                 }
             }
         }

--- a/Feature/Feature/VideoListView/ViewModel/VideoListViewInput.swift
+++ b/Feature/Feature/VideoListView/ViewModel/VideoListViewInput.swift
@@ -10,4 +10,5 @@ import Foundation
 public enum VideoListViewInput {
     case viewDidLoad
     case appendVideo(url: URL)
+    case validateSynchronization
 }

--- a/Feature/Feature/VideoListView/ViewModel/VideoListViewOutput.swift
+++ b/Feature/Feature/VideoListView/ViewModel/VideoListViewOutput.swift
@@ -9,4 +9,5 @@ import Foundation
 
 public enum VideoListViewOutput {
     case videoListDidChanged(videos: [VideoListItem])
+    case readyForNextScreen
 }


### PR DESCRIPTION
## 관련 이슈

- #44 
- #56

## ✅ 완료 및 수정 내역
- 의존성 등록
- UseCase 작성
- Repository 연동
- 동영상 동기화 로직 구현

## 🛠️ 테스트 방법
SocketProvider를 수정해서 기본적으로 통신이 가능한 상황에서 테스트 했습니다. (깜빡하고 테스트 코드를 올렸습니다. ㅜㅜ 기존 로직 복원하는 커밋 추가했습니다)<br>
동시에 synchronized 확인이 되었을 때 TempViewController를 present하는 방법으로 했고, 지금은 navigationController.push로 바꾸어 놓았습니다.

## 📝 리뷰 노트

동영상 업로드를 마친 상황에서 다음 버튼을 누르면 -> 피어들에게 해시 값을 비교하도록 요청 -> 해시 값에 대한 SyncMessage 리턴 -> SyncMessage 결과를 딕셔너리로 저장하여 모두 true일 경우 화면 전환 플래그 전송 + 화면 전환

현재는 이렇게 로직이 구현되어 있는데, 정상적인 경우만 테스트 하였고 예외 상황에 대한 처리는 작업 후 따로 PR을 만들어서 올려야 할 것 같습니다. (이 부분에서 시간이 많이 걸릴 것 같습니다.)<br>

고민되는 부분은 다음과 같습니다.
- SyncMessage는 어디에 위치해야 하는지?
- Core를 여기 저기서 사용하고 있는데 괜찮을지?

## 📱 스크린샷(선택)

https://github.com/user-attachments/assets/b9f73855-83de-4d5e-b8df-e1bc9c7d311f


