### PR TITLE
[Feature/#58] 그룹 퇴장 기능 로직 구현 및 UI 연결

### DIFF
--- a/Data/Data/ConnectedUserRepository.swift
+++ b/Data/Data/ConnectedUserRepository.swift
@@ -34,6 +34,9 @@ public extension ConnectedUserRepository {
         return socketProvider.connectedPeers()
             .compactMap({ mappingToConnectedUser($0) })
     }
+    func leaveGroup() {
+        socketProvider.disconnectAllUser()
+    }
 }
 
 // MARK: - Private Methods

--- a/Data/P2PSocket/SocketProvidable.swift
+++ b/Data/P2PSocket/SocketProvidable.swift
@@ -9,7 +9,7 @@ import Combine
 import Foundation
 
 public protocol SocketProvidable:
-    SocketInvitable, SocketBwrosable, SocketAdvertiseable,
+    SocketInvitable, SocketBwrosable, SocketAdvertiseable, SocketDisconnectable,
     SocketResourceSendable, HashSynchronizable { }
 
 public protocol SocketAdvertiseable {
@@ -40,6 +40,10 @@ public protocol SocketInvitable {
 	
 	func startReceiveInvitation()
 	func stopReceiveInvitation()
+}
+
+public protocol SocketDisconnectable {
+    func disconnectAllUser()
 }
 
 public protocol SocketResourceSendable {

--- a/Data/P2PSocket/SocketProvider.swift
+++ b/Data/P2PSocket/SocketProvider.swift
@@ -126,6 +126,12 @@ public extension SocketProvider {
 		invitationHandler = nil
 	}
     
+    func disconnectAllUser() {
+        session.connectedPeers.forEach { peerID in
+            session.cancelConnectPeer(peerID)
+        }
+    }
+    
     func sendHashes(_ hashes: [String: String]) {
         guard let data = try? JSONSerialization.data(withJSONObject: hashes, options: []) else { return }
         try? session.send(data, toPeers: session.connectedPeers, with: .reliable)

--- a/Domain/Interfaces/RepositoryInterface/ConnectedUserRepositoryInterface.swift
+++ b/Domain/Interfaces/RepositoryInterface/ConnectedUserRepositoryInterface.swift
@@ -12,4 +12,5 @@ public protocol ConnectedUserRepositoryInterface {
     var updatedConnectedUser: PassthroughSubject<ConnectedUser, Never> { get }
 
     func fetchConnectedUsers() -> [ConnectedUser]
+    func leaveGroup()
 }

--- a/Domain/Interfaces/UseCaseInterface/ConnectedUserUseCaseInterface.swift
+++ b/Domain/Interfaces/UseCaseInterface/ConnectedUserUseCaseInterface.swift
@@ -14,4 +14,5 @@ public protocol ConnectedUserUseCaseInterface {
     init(repository: ConnectedUserRepositoryInterface)
 
     func fetchConnectedUsers() -> [ConnectedUser]
+    func leaveGroup()
 }

--- a/Domain/UseCase/ConnectedUserUseCase.swift
+++ b/Domain/UseCase/ConnectedUserUseCase.swift
@@ -29,6 +29,11 @@ public extension ConnectedUserUseCase {
 		connectedUsersID = connectedUsers.map { $0.id }
 		return connectedUsers
 	}
+    
+    func leaveGroup() {
+        repository.leaveGroup()
+        
+    }
 }
 
 // MARK: - Private Methods

--- a/Feature/Feature/GroupInfoView/GroupInfoViewController.swift
+++ b/Feature/Feature/GroupInfoView/GroupInfoViewController.swift
@@ -67,7 +67,6 @@ private extension GroupInfoViewController {
         view.addSubview(countView)
         view.addSubview(participantScrollView)
         view.addSubview(exitButton)
-        exitButton.isEnabled = false
         participantScrollView.addSubview(participantStackView)
     }
     
@@ -120,7 +119,12 @@ private extension GroupInfoViewController {
         )
         buttonConfig.cornerStyle = .large
         exitButton.configuration = buttonConfig
-
+        
+        let buttonAction = UIAction { [weak self] action in
+            self?.input.send(.exitGroupButtonDidTab)
+        }
+        exitButton.addAction(buttonAction, for: .primaryActionTriggered)
+        
         participantScrollView.backgroundColor = .clear
         participantScrollView.showsVerticalScrollIndicator = false
         participantScrollView.showsHorizontalScrollIndicator = false

--- a/Feature/Feature/GroupInfoView/ViewModel/GroupInfoViewModel.swift
+++ b/Feature/Feature/GroupInfoView/ViewModel/GroupInfoViewModel.swift
@@ -85,5 +85,7 @@ private extension GroupInfoViewModel {
         output.send(.groupCountDidChanged(count: users.count))
     }
     
-    func exitGroupButtonDidTab() { }
+    func exitGroupButtonDidTab() {
+        usecase.leaveGroup()
+    }
 }

--- a/Feature/Feature/MovieEditView/MovieEditViewController.swift
+++ b/Feature/Feature/MovieEditView/MovieEditViewController.swift
@@ -1,0 +1,8 @@
+//
+//  MovieEditViewController.swift
+//  Feature
+//
+//  Created by Yune gim on 11/26/24.
+//
+
+import Foundation

--- a/Feature/Feature/MovieEditView/ViewModel/MovieEditViewMInput.swift
+++ b/Feature/Feature/MovieEditView/ViewModel/MovieEditViewMInput.swift
@@ -1,0 +1,8 @@
+//
+//  MovieEditViewMInput.swift
+//  Feature
+//
+//  Created by Yune gim on 11/26/24.
+//
+
+import Foundation

--- a/Feature/Feature/MovieEditView/ViewModel/MovieEditViewMOutput.swift
+++ b/Feature/Feature/MovieEditView/ViewModel/MovieEditViewMOutput.swift
@@ -1,0 +1,8 @@
+//
+//  MovieEditViewMOutput.swift
+//  Feature
+//
+//  Created by Yune gim on 11/26/24.
+//
+
+import Foundation

--- a/Feature/Feature/MovieEditView/ViewModel/MovieEditViewModel.swift
+++ b/Feature/Feature/MovieEditView/ViewModel/MovieEditViewModel.swift
@@ -1,0 +1,8 @@
+//
+//  MovieEditViewModel.swift
+//  Feature
+//
+//  Created by Yune gim on 11/26/24.
+//
+
+import Foundation


### PR DESCRIPTION
## 관련 이슈

- https://github.com/boostcampwm-2024/iOS09-BeStory/issues/58

## ✅ 완료 및 수정 내역

- SokcetProvider에 그룹 나가기 기능 구현
- Connected~ 계열 유즈케이스, 레포지토리에 그룹 나가기 기능을 호출하는 인터페이스 추가
- GroupInfoViewController - GroupInfoViewModel - 유즈케이스 연결

## 🛠️ 테스트 방법

- // 아직 테스트 코드가 없습니다. 직접 실행하여 테스트 가능합니다.

## 📝 리뷰 노트

- SokcetProvider내에 session의 메서드 중 cancelConnectPeer를 사용해 현재 세션의 모든 피어와 Disconnect
- 피어와 Disconnect되면 session(_, peer, didChange) 로 콜백이 들어오고, 기존 구현된 로직으로 유저 삭제 처리

## 📱 스크린샷(선택)
![1](https://github.com/user-attachments/assets/f7a87409-e450-4cb2-919d-4c27e3207756)
