### PR TITLE
[Feature/#62] CRDT 구현

### DIFF
--- a/Data/CRDT/LWWElementSet.swift
+++ b/Data/CRDT/LWWElementSet.swift
@@ -1,0 +1,56 @@
+//
+//  LWWElementSet.swift
+//  Data
+//
+//  Created by 이숲 on 11/27/24.
+//
+
+import Foundation
+
+public final class LWWElementSet<T: Hashable> {
+    private var additions: [T: Timestamp] = [:]
+    private var removals: [T: Timestamp] = [:]
+    private let queue = DispatchQueue(label: "crdt.queue", attributes: .concurrent)
+
+    public func add(element: T, timestamp: Timestamp) {
+        queue.async(flags: .barrier) {
+            if let existingTimestamp = self.additions[element], existingTimestamp >= timestamp {
+                return
+            }
+            self.additions[element] = timestamp
+        }
+    }
+
+    public func remove(element: T, timestamp: Timestamp) {
+        queue.async(flags: .barrier) {
+            if let existingTimestamp = self.removals[element], existingTimestamp >= timestamp {
+                return
+            }
+            self.removals[element] = timestamp
+        }
+    }
+
+    public func merge(with otherSet: LWWElementSet<T>) {
+        queue.async(flags: .barrier) {
+            for (element, timestamp) in otherSet.additions {
+                self.add(element: element, timestamp: timestamp)
+            }
+            for (element, timestamp) in otherSet.removals {
+                self.remove(element: element, timestamp: timestamp)
+            }
+        }
+    }
+
+    public func elements() -> [T] {
+        var result: [T] = []
+        queue.sync {
+            for (element, addTimestamp) in additions {
+                if let removeTimestamp = removals[element], removeTimestamp >= addTimestamp {
+                    continue
+                }
+                result.append(element)
+            }
+        }
+        return result
+    }
+}

--- a/Data/CRDT/LWWElementSet.swift
+++ b/Data/CRDT/LWWElementSet.swift
@@ -7,50 +7,50 @@
 
 import Foundation
 
-public final class LWWElementSet<T: Hashable> {
+public actor LWWElementSet<T: Hashable> {
     private var additions: [T: Timestamp] = [:]
     private var removals: [T: Timestamp] = [:]
-    private let queue = DispatchQueue(label: "crdt.queue", attributes: .concurrent)
 
     public func add(element: T, timestamp: Timestamp) {
-        queue.async(flags: .barrier) {
-            if let existingTimestamp = self.additions[element], existingTimestamp >= timestamp {
-                return
-            }
-            self.additions[element] = timestamp
+        if let existingTimestamp = self.additions[element], existingTimestamp >= timestamp {
+            return
         }
+        self.additions[element] = timestamp
+
     }
 
     public func remove(element: T, timestamp: Timestamp) {
-        queue.async(flags: .barrier) {
-            if let existingTimestamp = self.removals[element], existingTimestamp >= timestamp {
-                return
-            }
-            self.removals[element] = timestamp
+        if let existingTimestamp = self.removals[element], existingTimestamp >= timestamp {
+            return
         }
+        self.removals[element] = timestamp
+
     }
 
-    public func merge(with otherSet: LWWElementSet<T>) {
-        queue.async(flags: .barrier) {
-            for (element, timestamp) in otherSet.additions {
-                self.add(element: element, timestamp: timestamp)
-            }
-            for (element, timestamp) in otherSet.removals {
-                self.remove(element: element, timestamp: timestamp)
-            }
+    public func merge(with otherSet: LWWElementSet<T>) async {
+        let otherAdditions = await otherSet.additions
+        let otherRemovals = await otherSet.removals
+
+        for (element, timestamp) in otherAdditions {
+            self.add(element: element, timestamp: timestamp)
         }
+
+        for (element, timestamp) in otherRemovals {
+            self.remove(element: element, timestamp: timestamp)
+        }
+
     }
 
     public func elements() -> [T] {
         var result: [T] = []
-        queue.sync {
-            for (element, addTimestamp) in additions {
-                if let removeTimestamp = removals[element], removeTimestamp >= addTimestamp {
-                    continue
-                }
-                result.append(element)
+
+        for (element, addTimestamp) in additions {
+            if let removeTimestamp = removals[element], removeTimestamp >= addTimestamp {
+                continue
             }
+            result.append(element)
         }
+
         return result
     }
 }

--- a/Data/CRDT/Timestamp.swift
+++ b/Data/CRDT/Timestamp.swift
@@ -1,0 +1,32 @@
+//
+//  Timestamp.swift
+//  Data
+//
+//  Created by 이숲 on 11/27/24.
+//
+
+import Foundation
+
+public struct Timestamp: Comparable {
+    let replicaID: String
+    let counter: Int
+    let date: Date
+
+    public init(
+        replicaID: String,
+        counter: Int,
+        date: Date
+    ) {
+        self.replicaID = replicaID
+        self.counter = counter
+        self.date = date
+    }
+
+    public static func < (lhs: Timestamp, rhs: Timestamp) -> Bool {
+        if lhs.counter == rhs.counter {
+            return lhs.date < rhs.date
+        }
+
+        return lhs.counter < rhs.counter
+    }
+}

--- a/Data/Data.xcodeproj/project.pbxproj
+++ b/Data/Data.xcodeproj/project.pbxproj
@@ -7,12 +7,20 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		853CF9162CF6D92700936AD3 /* CRDT.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 853CF8F82CF6CAD000936AD3 /* CRDT.framework */; };
 		D9CF36472CF0858200B1A92D /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D9CF36462CF0858200B1A92D /* Core.framework */; };
 		FEF779662CDCB2CF00FFE089 /* Entity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FEF779652CDCB2CF00FFE089 /* Entity.framework */; };
 		FEF779962CDCE10300FFE089 /* Interfaces.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FEF779952CDCE10300FFE089 /* Interfaces.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		853CF9002CF6CAED00936AD3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FE6EF3242CD8B020005DC39D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 853CF8F72CF6CAD000936AD3;
+			remoteInfo = CRDT;
+		};
 		FEF779692CDCB2D500FFE089 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = FE6EF3242CD8B020005DC39D /* Project object */;
@@ -45,6 +53,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		853CF8F82CF6CAD000936AD3 /* CRDT.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CRDT.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D9CF36462CF0858200B1A92D /* Core.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FED9682A2CD9094300CD445C /* libData.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libData.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		FED968552CD90FCF00CD445C /* P2PSocket.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = P2PSocket.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -65,6 +74,11 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		853CF8F92CF6CAD000936AD3 /* CRDT */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = CRDT;
+			sourceTree = "<group>";
+		};
 		FE6EF32E2CD8B020005DC39D /* Data */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
@@ -81,6 +95,13 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		853CF8F52CF6CAD000936AD3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FED968272CD9094300CD445C /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -94,6 +115,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				853CF9162CF6D92700936AD3 /* CRDT.framework in Frameworks */,
 				D9CF36472CF0858200B1A92D /* Core.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -106,6 +128,7 @@
 			children = (
 				FE6EF32E2CD8B020005DC39D /* Data */,
 				FED968562CD90FCF00CD445C /* P2PSocket */,
+				853CF8F92CF6CAD000936AD3 /* CRDT */,
 				FED967FA2CD9026100CD445C /* Frameworks */,
 				FE6EF32D2CD8B020005DC39D /* Products */,
 			);
@@ -116,6 +139,7 @@
 			children = (
 				FED9682A2CD9094300CD445C /* libData.a */,
 				FED968552CD90FCF00CD445C /* P2PSocket.framework */,
+				853CF8F82CF6CAD000936AD3 /* CRDT.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -133,6 +157,13 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		853CF8F32CF6CAD000936AD3 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FED968502CD90FCF00CD445C /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -143,6 +174,29 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		853CF8F72CF6CAD000936AD3 /* CRDT */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 853CF8FF2CF6CAD000936AD3 /* Build configuration list for PBXNativeTarget "CRDT" */;
+			buildPhases = (
+				853CF8F32CF6CAD000936AD3 /* Headers */,
+				853CF8F42CF6CAD000936AD3 /* Sources */,
+				853CF8F52CF6CAD000936AD3 /* Frameworks */,
+				853CF8F62CF6CAD000936AD3 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				853CF8F92CF6CAD000936AD3 /* CRDT */,
+			);
+			name = CRDT;
+			packageProductDependencies = (
+			);
+			productName = CRDT;
+			productReference = 853CF8F82CF6CAD000936AD3 /* CRDT.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		FED968292CD9094300CD445C /* Data */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = FED9682E2CD9094300CD445C /* Build configuration list for PBXNativeTarget "Data" */;
@@ -156,6 +210,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				853CF9012CF6CAED00936AD3 /* PBXTargetDependency */,
 				FEF7796A2CDCB2D500FFE089 /* PBXTargetDependency */,
 			);
 			name = Data;
@@ -199,6 +254,10 @@
 				LastSwiftUpdateCheck = 1600;
 				LastUpgradeCheck = 1610;
 				TargetAttributes = {
+					853CF8F72CF6CAD000936AD3 = {
+						CreatedOnToolsVersion = 16.1;
+						LastSwiftMigration = 1610;
+					};
 					FED968292CD9094300CD445C = {
 						CreatedOnToolsVersion = 16.0;
 					};
@@ -224,11 +283,19 @@
 			targets = (
 				FED968292CD9094300CD445C /* Data */,
 				FED968542CD90FCF00CD445C /* P2PSocket */,
+				853CF8F72CF6CAD000936AD3 /* CRDT */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		853CF8F62CF6CAD000936AD3 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FED968532CD90FCF00CD445C /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -278,6 +345,13 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		853CF8F42CF6CAD000936AD3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FED968262CD9094300CD445C /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -295,6 +369,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		853CF9012CF6CAED00936AD3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 853CF8F72CF6CAD000936AD3 /* CRDT */;
+			targetProxy = 853CF9002CF6CAED00936AD3 /* PBXContainerItemProxy */;
+		};
 		FEF7796A2CDCB2D500FFE089 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = FED968542CD90FCF00CD445C /* P2PSocket */;
@@ -303,6 +382,81 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		853CF8FC2CF6CAD000936AD3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = B3PWYBKFUK;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				PRODUCT_BUNDLE_IDENTIFIER = kr.codesquad.boostcamp9.bestory.crdt.CRDT;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		853CF8FD2CF6CAD000936AD3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = B3PWYBKFUK;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				PRODUCT_BUNDLE_IDENTIFIER = kr.codesquad.boostcamp9.bestory.crdt.CRDT;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 		FE6EF3422CD8B021005DC39D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -552,6 +706,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		853CF8FF2CF6CAD000936AD3 /* Build configuration list for PBXNativeTarget "CRDT" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				853CF8FC2CF6CAD000936AD3 /* Debug */,
+				853CF8FD2CF6CAD000936AD3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		FE6EF3272CD8B020005DC39D /* Build configuration list for PBXProject "Data" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (


### PR DESCRIPTION
## 관련 이슈

- https://github.com/boostcampwm-2024/iOS09-BeStory/issues/62

## ✅ 완료 및 수정 내역

- [x] 가장 기본적인 LWW CRDT 구현

## 🛠️ 테스트 방법

- 아직 테스트 코드가 없습니다.

## 📝 리뷰 노트

### 💡 참고 블로그
- https://blog.stackademic.com/understanding-crdts-and-lww-with-swift-a-deep-dive-dc98205e3aae

### 💡 LWWR의 확장 형태인 LWW Element Set
LWWR은 단일값을 관리합니다. 하지만, BeStory는 단일값이 아닌, 영상 집합을 관리해야하기 때문에 Element Set으로 확장된 형태를 채택했습니다. 

특성 | LWWR | 현재 구현 (LWW Element Set)
-- | -- | --
데이터 구조 | 단일 값(Register) 관리 | 여러 값(Set) 관리
타임스탬프 기반 충돌 해결 | 가장 최근 값으로 덮어씀 | 가장 최근의 추가/삭제 작업만 반영
추가/삭제 관리 | 없음 | 추가/삭제를 모두 관리
병합(merge) | 단일 값 병합 | Set 병합

### 💡 add & remove, 그리고 merge
add 와 remove는 단일 요소에 대해 queue에 있는 수정 사항 중 마지막 갚으로 덮어씁니다. 
merge는 socket으로 부터 대조군(LWWElementSet)을 받고, 대조군의 additions와 removals를 비교하여 각각의 요소를 덮어씁니다.
여기서 대조군은 동시에 편집된 여러 요소 정보를 가지고있는 (temporary set)이 될 수 있습니다.

### ⚠️ 더 구체적인 구현을 위해 필요한 사항 및 결정해야할 사항
| ⭐️ 공유를 위해 PR을 일찍 올렸습니다. 아직 논의와 추가 구현이 필요합니다.

1. LWW가 생각보다 많이 단순합니다. 
결국 Socket에서 많은 처리가 이루어지게 되는데, Socket의 부담을 줄이기 위해 Socket의 역할을 가져올지에 대한 결정이 필요합니다.
2. 만약 Socket의 역할을 가져온다면, 영상에 대한 타입이 어떻게되는지 알 필요가 있습니다.
예를 들어, 다음과 같은 타입으로 정보가 전달되고,
```swift
struct VideoClip: Hashable {
    let id: UUID
    var name: String
    var startTime: CMTime // 클립 시작 시간
    var endTime: CMTime // 클립 종료 시간
    var position: Int // 클립 순서
}
```
각 편집 이벤트에 대한 처리를 다음과 같은 이벤트로 처리한다 했을 때 구현될 코드가 달라집니다.
```swift
struct EditEvent: Codable {
    enum EventType: String, Codable {
        case updateLength
        case updateOrder
    }

    let type: EventType
    let clipID: UUID
    let newStartTime: CMTime?
    let newEndTime: CMTime?
    let newPosition: Int?
    let timestamp: Timestamp
}
```

3. 만약 역할을 가져오지 않는다면, LWW에서 더 구현해야할 점이 무엇이 있을까 싶기도 합니다. 이에 대해서는 필요한 구현 부분에 대해 말씀해주시면 반영하겠습니다.

## 📱 스크린샷(선택)

