### PR TITLE
[Feature/#56] 동영상 동기화 로직 구현

### DIFF
--- a/App/App/AppDelegate.swift
+++ b/App/App/AppDelegate.swift
@@ -12,6 +12,7 @@ import Core
 class AppDelegate: UIResponder, UIApplicationDelegate {
 	func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 		// Override point for customization after application launch.
+        FileSystemManager.shared.deleteAllFiles()
 		return true
 	}
 	
@@ -20,9 +21,5 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 		// Called when a new scene session is being created.
 		// Use this method to select a configuration to create the new scene with.
 		return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
-	}
-    
-    func applicationWillTerminate(_ application: UIApplication) {
-        FileSystemManager.shared.deleteAllFiles()
     }
 }

--- a/Core/Utilities/FileSystemManager.swift
+++ b/Core/Utilities/FileSystemManager.swift
@@ -5,14 +5,13 @@
 //  Created by 디해 on 11/15/24.
 //
 
-import CryptoKit
 import Foundation
 
 public final class FileSystemManager {
     public static let shared = FileSystemManager()
-
+    public let folder: URL
+    
     private let fileManager = FileManager.default
-    private let folder: URL
     private let folderName: String = "videos"
     
     private init() {
@@ -46,26 +45,5 @@ public final class FileSystemManager {
         fileURLs.forEach { url in
             try? fileManager.removeItem(at: url)
         }
-    }
-    
-    public func collectHashes() -> [String: String] {
-        var fileHashes = [String: String]()
-        
-        guard let fileURLs = try? fileManager.contentsOfDirectory(
-            at: folder,
-            includingPropertiesForKeys: nil
-        ) else { return [:] }
-        for fileURL in fileURLs {
-            guard let hash = calculateFileHash(for: fileURL) else { return [:] }
-            fileHashes[fileURL.lastPathComponent] = hash
-        }
-        
-        return fileHashes
-    }
-    
-    private func calculateFileHash(for fileURL: URL) -> String? {
-        guard let fileData = try? Data(contentsOf: fileURL) else { return nil }
-        let hash = SHA256.hash(data: fileData)
-        return hash.compactMap { String(format: "%02x", $0) }.joined()
     }
 }

--- a/Core/Utilities/FileSystemManager.swift
+++ b/Core/Utilities/FileSystemManager.swift
@@ -31,9 +31,8 @@ public final class FileSystemManager {
             originalFileName += ".mp4"
         }
         let destinationURL = folder.appending(path: originalFileName)
-        if !fileManager.fileExists(atPath: destinationURL.path) {
-            try? fileManager.copyItem(at: tempURL, to: destinationURL)
-        }
+        guard !fileManager.fileExists(atPath: destinationURL.path) else { return nil }
+        try? fileManager.copyItem(at: tempURL, to: destinationURL)
         return destinationURL
     }
     

--- a/Core/Utilities/Synchronizer.swift
+++ b/Core/Utilities/Synchronizer.swift
@@ -1,0 +1,55 @@
+//
+//  Synchronizer.swift
+//  Core
+//
+//  Created by 디해 on 11/27/24.
+//
+
+import CryptoKit
+import Foundation
+
+public final class Synchronizer {
+    private let fileManager = FileManager.default
+    private let folder: URL
+    
+    public init(folder: URL) {
+        self.folder = folder
+    }
+    
+    public func compareToLocal(with hashes: [String: String]) -> [String: HashCondition] {
+        let localHashes = collectHashes()
+        var result: [String: HashCondition] = [:]
+        
+        for (fileName, _) in localHashes where hashes[fileName] == nil {
+            result[fileName] = .additional
+        }
+        
+        for (fileName, _) in hashes where localHashes[fileName] == nil {
+            result[fileName] = .missing
+        }
+    
+        return result
+    }
+    
+    public func collectHashes() -> [String: String] {
+        var fileHashes = [String: String]()
+        
+        guard let fileURLs = try? fileManager.contentsOfDirectory(
+            at: folder,
+            includingPropertiesForKeys: nil
+        ) else { return [:] }
+        for fileURL in fileURLs {
+            guard let hash = calculateFileHash(for: fileURL) else { return [:] }
+            fileHashes[fileURL.lastPathComponent] = hash
+        }
+        
+        return fileHashes
+    }
+    
+    private func calculateFileHash(for fileURL: URL) -> String? {
+        guard let fileData = try? Data(contentsOf: fileURL) else { return nil }
+        let hash = SHA256.hash(data: fileData)
+        return hash.compactMap { String(format: "%02x", $0) }.joined()
+    }
+}
+

--- a/Core/Utilities/Synchronizer.swift
+++ b/Core/Utilities/Synchronizer.swift
@@ -20,12 +20,12 @@ public final class Synchronizer {
         let localHashes = collectHashes()
         var result: [String: HashCondition] = [:]
         
-        for (fileName, _) in localHashes where hashes[fileName] == nil {
-            result[fileName] = .additional
+        localHashes.filter { hashes[$0.key] == nil }.keys.forEach {
+            result[$0] = .additional
         }
         
-        for (fileName, _) in hashes where localHashes[fileName] == nil {
-            result[fileName] = .missing
+        hashes.filter { localHashes[$0.key] == nil }.keys.forEach {
+            result[$0] = .missing
         }
     
         return result

--- a/Core/Utilities/Synchronizer.swift
+++ b/Core/Utilities/Synchronizer.swift
@@ -53,3 +53,7 @@ public final class Synchronizer {
     }
 }
 
+@frozen public enum HashCondition: Codable {
+    case missing
+    case additional
+}

--- a/Data/Data.xcodeproj/project.pbxproj
+++ b/Data/Data.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		853CF9162CF6D92700936AD3 /* CRDT.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 853CF8F82CF6CAD000936AD3 /* CRDT.framework */; };
 		D9CF36472CF0858200B1A92D /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D9CF36462CF0858200B1A92D /* Core.framework */; };
 		FEF779662CDCB2CF00FFE089 /* Entity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FEF779652CDCB2CF00FFE089 /* Entity.framework */; };
 		FEF779962CDCE10300FFE089 /* Interfaces.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FEF779952CDCE10300FFE089 /* Interfaces.framework */; };
@@ -89,7 +88,6 @@
 		};
 		FED968562CD90FCF00CD445C /* P2PSocket */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-
 			path = P2PSocket;
 			sourceTree = "<group>";
 		};
@@ -116,7 +114,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				853CF9162CF6D92700936AD3 /* CRDT.framework in Frameworks */,
 				D9CF36472CF0858200B1A92D /* Core.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -149,7 +146,6 @@
 			isa = PBXGroup;
 			children = (
 				D9CF36462CF0858200B1A92D /* Core.framework */,
-
 				FEF779952CDCE10300FFE089 /* Interfaces.framework */,
 				FEF779652CDCB2CF00FFE089 /* Entity.framework */,
 			);

--- a/Data/Data/SharingVideoRepository.swift
+++ b/Data/Data/SharingVideoRepository.swift
@@ -112,7 +112,7 @@ private extension SharingVideoRepository {
             let completion: (((any Error)?) -> Void)? = (index == fileNames.count - 1) ? { _ in
                 self.sendResponse(isRequested: isRequested, to: peerID) } : nil
             
-            socketProvider.shareResource(url: fileURL,
+            socketProvider.sendResource(url: fileURL,
                                          resourceName: fileName,
                                          to: peerID,
                                          completion: completion)
@@ -146,7 +146,7 @@ private extension SharingVideoRepository {
 // MARK: - Public Methods
 public extension SharingVideoRepository {
     func shareVideo(url: URL, resourceName: String) async throws {
-        try await socketProvider.shareResource(url: url, resourceName: resourceName)
+        try await socketProvider.sendResourceToAll(url: url, resourceName: resourceName)
     }
     
     func fetchVideos() -> [SharedVideo] {

--- a/Data/Data/SharingVideoRepository.swift
+++ b/Data/Data/SharingVideoRepository.swift
@@ -58,6 +58,14 @@ public extension SharingVideoRepository {
     func synchronizeVideos() {
         let hashes = FileSystemManager.shared.collectHashes()
         socketProvider.sendHashes(hashes)
+extension SharingVideoRepository {
+    enum SyncMessage: Codable {
+        case hash([String: String])
+        case hashMatch([String: HashCondition])
+        case request([String])
+        case sendResponse
+        case receiveResponse
+        case completed
     }
 
 }

--- a/Data/Data/SharingVideoRepository.swift
+++ b/Data/Data/SharingVideoRepository.swift
@@ -36,6 +36,7 @@ public final class SharingVideoRepository: SharingVideoRepositoryInterface {
                 self?.mappingToSharedVideo(resource)
             }
             .subscribe(updatedSharedVideo)
+            .store(in: &cancellables)
         
         socketProvider.dataShared
             .sink { [weak self] (data, peerID) in
@@ -162,8 +163,7 @@ public extension SharingVideoRepository {
         
         guard let encodedData = try? JSONEncoder().encode(hashMessage) else { return }
         socketProvider.sendAll(data: encodedData)
-        
-        for peer in socketProvider.connectedPeers().map({ $0.id }) {
+        for peer in socketProvider.connectedPeers().filter({ $0.state == .connected || $0.state == .pending }).map({ $0.id }) {
             sendSyncFlags[peer] = false
             receiveSyncFlags[peer] = false
         }

--- a/Data/Data/SharingVideoRepository.swift
+++ b/Data/Data/SharingVideoRepository.swift
@@ -162,7 +162,6 @@ public extension SharingVideoRepository {
         
         guard let encodedData = try? JSONEncoder().encode(hashMessage) else { return }
         socketProvider.sendAll(data: encodedData)
-
         
         for peer in socketProvider.connectedPeerIDs {
             sendSyncFlags[peer] = false

--- a/Data/Data/SharingVideoRepository.swift
+++ b/Data/Data/SharingVideoRepository.swift
@@ -16,6 +16,15 @@ import Core
 public final class SharingVideoRepository: SharingVideoRepositoryInterface {
     private var cancellables: Set<AnyCancellable> = []
     private let socketProvider: SocketProvidable
+    private let synchronizer = Synchronizer(
+        folder: FileSystemManager.shared.folder)
+    
+    private var hasMismatch: Bool = false
+    private var sendSyncFlags: [String: Bool] = [:]
+    private var receiveSyncFlags: [String: Bool] = [:]
+    private var allSynced: Bool {
+        sendSyncFlags.values.allSatisfy { $0 } && receiveSyncFlags.values.allSatisfy { $0 }
+    }
 
     public let updatedSharedVideo = PassthroughSubject<SharedVideo, Never>()
     public let isSynchronized = PassthroughSubject<Void, Never>()
@@ -28,10 +37,29 @@ public final class SharingVideoRepository: SharingVideoRepositoryInterface {
             }
             .subscribe(updatedSharedVideo)
         
-        socketProvider.isSynchronized
-            .subscribe(isSynchronized)
-            .store(in: &cancellables)
-
+        socketProvider.dataShared
+            .sink { [weak self] (data, peerID) in
+                guard let data = try? JSONDecoder().decode(SyncMessage.self, from: data) else { return }
+                switch data {
+                case .hash(let hashes):
+                    self?.sendComparingResult(with: hashes, to: peerID)
+                case .hashMatch(let result):
+                    self?.synchronize(with: result, to: peerID)
+                case .request(let fileNames):
+                    self?.sendFiles(fileNames: fileNames, to: peerID, isRequested: true)
+                case .sendResponse:
+                    guard let self else { return }
+                    sendSyncFlags[peerID] = true
+                    checkIfAllSynced()
+                case .receiveResponse:
+                    guard let self else { return }
+                    receiveSyncFlags[peerID]  = true
+                    checkIfAllSynced()
+                case .completed:
+                    self?.isSynchronized.send(())
+                }
+            }
+            .store(in: &cancellables)    
     }
 }
 
@@ -39,6 +67,79 @@ public final class SharingVideoRepository: SharingVideoRepositoryInterface {
 private extension SharingVideoRepository {
     func mappingToSharedVideo(_ resource: SharedResource) -> SharedVideo {
         return .init(localUrl: resource.localUrl, author: resource.sender)
+    }
+    
+    func broadcastCompleted() {
+        guard let completedMessage = try? JSONEncoder().encode(SyncMessage.completed) else { return }
+        socketProvider.sendAll(data: completedMessage)
+        isSynchronized.send(())
+    }
+    
+    func sendComparingResult(with hashes: [String: String], to peerID: String) {
+        let result = synchronizer.compareToLocal(with: hashes)
+        let hashMessage = SyncMessage.hashMatch(result)
+        
+        guard let serializedData = try? JSONEncoder().encode(hashMessage) else { return }
+        socketProvider.send(data: serializedData, to: peerID)
+    }
+    
+    func synchronize(with result: [String: HashCondition], to peerID: String) {
+        if result.isEmpty {
+            sendSyncFlags[peerID] = true
+            receiveSyncFlags[peerID] = true
+            checkIfAllSynced()
+            return
+        }
+        
+        hasMismatch = true
+        
+        let missingFiles = result.filter { $0.value == .missing }.map { $0.key }
+        let additionalFiles = result.filter { $0.value == .additional }.map { $0.key }
+        
+        sendFiles(fileNames: missingFiles, to: peerID, isRequested: false)
+        requestFiles(fileNames: additionalFiles, to: peerID)
+    }
+    
+    func sendFiles(fileNames: [String], to peerID: String, isRequested: Bool) {
+        guard !fileNames.isEmpty else {
+            sendResponse(isRequested: isRequested, to: peerID)
+            return
+        }
+        
+        for index in fileNames.indices {
+            let fileName = fileNames[index]
+            let fileURL = FileSystemManager.shared.folder.appending(component: fileName)
+            let completion: (((any Error)?) -> Void)? = (index == fileNames.count - 1) ? { _ in
+                self.sendResponse(isRequested: isRequested, to: peerID) } : nil
+            
+            socketProvider.shareResource(url: fileURL,
+                                         resourceName: fileName,
+                                         to: peerID,
+                                         completion: completion)
+        }
+    }
+    
+    func requestFiles(fileNames: [String], to peerID: String) {
+        guard !fileNames.isEmpty else { return }
+        let request = SyncMessage.request(fileNames)
+        guard let requestData = try? JSONEncoder().encode(request) else { return }
+        socketProvider.send(data: requestData, to: peerID)
+    }
+    
+    func sendResponse(isRequested: Bool, to peerID: String) {
+        let responseFlag = isRequested ? SyncMessage.receiveResponse : SyncMessage.sendResponse
+        guard let responseData = try? JSONEncoder().encode(responseFlag) else { return }
+        self.socketProvider.send(data: responseData, to: peerID)
+    }
+    
+    func checkIfAllSynced() {
+        if allSynced {
+            if hasMismatch {
+                broadcastHashes()
+            } else {
+                broadcastCompleted()
+            }
+        }
     }
 }
 
@@ -54,10 +155,23 @@ public extension SharingVideoRepository {
                 self?.mappingToSharedVideo(resource)
             }
     }
+    
+    func broadcastHashes() {
+        let collectedHashes = synchronizer.collectHashes()
+        let hashMessage = SyncMessage.hash(collectedHashes)
+        
+        guard let encodedData = try? JSONEncoder().encode(hashMessage) else { return }
+        socketProvider.sendAll(data: encodedData)
 
-    func synchronizeVideos() {
-        let hashes = FileSystemManager.shared.collectHashes()
-        socketProvider.sendHashes(hashes)
+        
+        for peer in socketProvider.connectedPeerIDs {
+            sendSyncFlags[peer] = false
+            receiveSyncFlags[peer] = false
+        }
+        hasMismatch = false
+    }
+}
+
 extension SharingVideoRepository {
     enum SyncMessage: Codable {
         case hash([String: String])

--- a/Data/Data/SharingVideoRepository.swift
+++ b/Data/Data/SharingVideoRepository.swift
@@ -98,6 +98,11 @@ private extension SharingVideoRepository {
     }
     
     func sendFiles(fileNames: [String], to peerID: String, isRequested: Bool) {
+        guard !fileNames.isEmpty else {
+            sendSyncFlags[peerID] = true
+            return
+        }
+        
         Task {
             for index in fileNames.indices {
                 let fileName = fileNames[index]
@@ -116,7 +121,11 @@ private extension SharingVideoRepository {
     }
     
     func requestFiles(fileNames: [String], to peerID: String) {
-        guard !fileNames.isEmpty else { return }
+        guard !fileNames.isEmpty else {
+            receiveSyncFlags[peerID] = true
+            return
+        }
+        
         let request = SyncMessage.request(fileNames)
         guard let requestData = try? JSONEncoder().encode(request) else { return }
         socketProvider.send(data: requestData, to: peerID)

--- a/Data/Data/SharingVideoRepository.swift
+++ b/Data/Data/SharingVideoRepository.swift
@@ -163,7 +163,7 @@ public extension SharingVideoRepository {
         guard let encodedData = try? JSONEncoder().encode(hashMessage) else { return }
         socketProvider.sendAll(data: encodedData)
         
-        for peer in socketProvider.connectedPeerIDs {
+        for peer in socketProvider.connectedPeers().map({ $0.id }) {
             sendSyncFlags[peer] = false
             receiveSyncFlags[peer] = false
         }

--- a/Data/P2PSocket/SocketProvidable.swift
+++ b/Data/P2PSocket/SocketProvidable.swift
@@ -51,14 +51,14 @@ public protocol SocketDisconnectable {
 public protocol SocketResourceSendable {
 	var resourceShared: PassthroughSubject<SharedResource, Never> { get }
 	
-    func shareResource(
+    func sendResource(
         url localURL: URL,
         resourceName: String,
         to peerID: String,
         completion: (((any Error)?) -> Void)?
     )
 	/// 연결된 모든 Peer들에게 리소스를 전송합니다.
-    func shareResource(url: URL, resourceName: String) async throws
+    func sendResourceToAll(url: URL, resourceName: String) async throws
 	/// Peer들과 공유한 모든 리소스를 리턴합니다.
 	func sharedAllResources() -> [SharedResource]
 }

--- a/Data/P2PSocket/SocketProvidable.swift
+++ b/Data/P2PSocket/SocketProvidable.swift
@@ -54,9 +54,8 @@ public protocol SocketResourceSendable {
     func sendResource(
         url localURL: URL,
         resourceName: String,
-        to peerID: String,
-        completion: (((any Error)?) -> Void)?
-    )
+        to peerID: String
+    ) async
 	/// 연결된 모든 Peer들에게 리소스를 전송합니다.
     func sendResourceToAll(url: URL, resourceName: String) async throws
 	/// Peer들과 공유한 모든 리소스를 리턴합니다.

--- a/Data/P2PSocket/SocketProvidable.swift
+++ b/Data/P2PSocket/SocketProvidable.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public protocol SocketProvidable:
     SocketInvitable, SocketBwrosable, SocketAdvertiseable, SocketDisconnectable,
-    SocketResourceSendable, HashSynchronizable { }
+    SocketResourceSendable, DataSendable { }
 
 
 public protocol SocketAdvertiseable {

--- a/Data/P2PSocket/SocketProvidable.swift
+++ b/Data/P2PSocket/SocketProvidable.swift
@@ -52,8 +52,7 @@ public protocol SocketResourceSendable {
 	var resourceShared: PassthroughSubject<SharedResource, Never> { get }
 	
 	/// 연결된 모든 Peer들에게 리소스를 전송합니다.
-	@discardableResult
-  func shareResource(url: URL, resourceName: String) async throws -> SharedResource
+    func shareResource(url: URL, resourceName: String) async throws
 	/// Peer들과 공유한 모든 리소스를 리턴합니다.
 	func sharedAllResources() -> [SharedResource]
 }

--- a/Data/P2PSocket/SocketProvidable.swift
+++ b/Data/P2PSocket/SocketProvidable.swift
@@ -14,8 +14,6 @@ public protocol SocketProvidable:
 
 
 public protocol SocketAdvertiseable {
-    var connectedPeerIDs: [String] { get }
-    
 	func startAdvertising()
 	func stopAdvertising()
 }

--- a/Data/P2PSocket/SocketProvidable.swift
+++ b/Data/P2PSocket/SocketProvidable.swift
@@ -65,9 +65,10 @@ public protocol SocketResourceSendable {
 	func sharedAllResources() -> [SharedResource]
 }
 
-public protocol HashSynchronizable {
-    var isSynchronized: PassthroughSubject<Void, Never> { get }
+public protocol DataSendable {
+    var dataShared: PassthroughSubject<(Data, String), Never> { get }
     
-    func sendHashes(_ hashes: [String: String])
+    func send(data: Data, to peerID: String)
+    func sendAll(data: Data)
 }
 

--- a/Data/P2PSocket/SocketProvidable.swift
+++ b/Data/P2PSocket/SocketProvidable.swift
@@ -51,6 +51,12 @@ public protocol SocketDisconnectable {
 public protocol SocketResourceSendable {
 	var resourceShared: PassthroughSubject<SharedResource, Never> { get }
 	
+    func shareResource(
+        url localURL: URL,
+        resourceName: String,
+        to peerID: String,
+        completion: (((any Error)?) -> Void)?
+    )
 	/// 연결된 모든 Peer들에게 리소스를 전송합니다.
     func shareResource(url: URL, resourceName: String) async throws
 	/// Peer들과 공유한 모든 리소스를 리턴합니다.

--- a/Data/P2PSocket/SocketProvidable.swift
+++ b/Data/P2PSocket/SocketProvidable.swift
@@ -14,6 +14,8 @@ public protocol SocketProvidable:
 
 
 public protocol SocketAdvertiseable {
+    var connectedPeerIDs: [String] { get }
+    
 	func startAdvertising()
 	func stopAdvertising()
 }

--- a/Data/P2PSocket/SocketProvider.swift
+++ b/Data/P2PSocket/SocketProvider.swift
@@ -18,6 +18,14 @@ public final class SocketProvider: NSObject, SocketProvidable {
 	public let updatedPeer = PassthroughSubject<SocketPeer, Never>()
 	public let invitationReceived = PassthroughSubject<SocketPeer, Never>()
     public let resourceShared = PassthroughSubject<SharedResource, Never>()
+    
+    public var connectedPeerIDs: [String] {
+        session.connectedPeers.compactMap { peerID in
+            MCPeerIDStorage.shared.peerIDByIdentifier.first {
+                $0.value.id == peerID
+            }?.key
+        }
+    }
 	private var isAllowedInvitation: Bool = true
 	private var invitationHandler: ((Bool, MCSession?) -> Void)?
 	

--- a/Data/P2PSocket/SocketProvider.swift
+++ b/Data/P2PSocket/SocketProvider.swift
@@ -18,6 +18,7 @@ public final class SocketProvider: NSObject, SocketProvidable {
 	public let updatedPeer = PassthroughSubject<SocketPeer, Never>()
 	public let invitationReceived = PassthroughSubject<SocketPeer, Never>()
     public let resourceShared = PassthroughSubject<SharedResource, Never>()
+    public let dataShared = PassthroughSubject<(Data, String), Never>()
     
     public var connectedPeerIDs: [String] {
         session.connectedPeers.compactMap { peerID in
@@ -138,9 +139,15 @@ public extension SocketProvider {
         }
     }
     
-    func sendHashes(_ hashes: [String: String]) {
-        guard let data = try? JSONSerialization.data(withJSONObject: hashes, options: []) else { return }
+    func send(data: Data, to peerID: String) {
+        guard let mcPeerID = MCPeerIDStorage.shared.peerIDByIdentifier[peerID]?.id else { return }
+        try? session.send(data, toPeers: [mcPeerID], with: .reliable)
+    }
+    
+    func sendAll(data: Data) {
         try? session.send(data, toPeers: session.connectedPeers, with: .reliable)
+    }
+    
     func shareResource(
         url localURL: URL,
         resourceName: String,

--- a/Data/P2PSocket/SocketProvider.swift
+++ b/Data/P2PSocket/SocketProvider.swift
@@ -17,9 +17,7 @@ public final class SocketProvider: NSObject, SocketProvidable {
 	// MARK: - Properties
 	public let updatedPeer = PassthroughSubject<SocketPeer, Never>()
 	public let invitationReceived = PassthroughSubject<SocketPeer, Never>()
-  public let resourceShared = PassthroughSubject<SharedResource, Never>()
-  public let isSynchronized = PassthroughSubject<Void, Never>()
-
+    public let resourceShared = PassthroughSubject<SharedResource, Never>()
 	private var isAllowedInvitation: Bool = true
 	private var invitationHandler: ((Bool, MCSession?) -> Void)?
 	
@@ -27,9 +25,8 @@ public final class SocketProvider: NSObject, SocketProvidable {
 	private let browser: MCNearbyServiceBrowser
 	private let advertiser: MCNearbyServiceAdvertiser
 	private let session: MCSession
-  private var sharingTasks = [Task<(), Never>]()
-  private var sharedResources = [SharedResource]()
-  private var syncFlags: [MCPeerID: Bool] = [:]
+    private var sharingTasks = [Task<(), Never>]()
+    private var sharedResources = [SharedResource]()
     
 	// MARK: - Initializers
 	public override init() {
@@ -379,13 +376,5 @@ private extension SocketProvider {
             }
             self?.sharingTasks.append(task)
         }
-    }
-}
-
-private extension SocketProvider {
-    enum SyncMessage: Codable {
-        case hashMatch
-        case hashMismatch
-        case completed
     }
 }

--- a/Data/P2PSocket/SocketProvider.swift
+++ b/Data/P2PSocket/SocketProvider.swift
@@ -141,7 +141,7 @@ public extension SocketProvider {
         try? session.send(data, toPeers: session.connectedPeers, with: .reliable)
     }
     
-    func shareResource(
+    func sendResource(
         url localURL: URL,
         resourceName: String,
         to peerID: String,
@@ -157,7 +157,7 @@ public extension SocketProvider {
                              withCompletionHandler: completion)
     }
 	  
-    func shareResource(url localUrl: URL, resourceName: String) async throws {
+    func sendResourceToAll(url localUrl: URL, resourceName: String) async throws {
             let uuid = UUID()
             let nameWithUUID = [resourceName, uuid.uuidString].joined(separator: "/")
             

--- a/Data/P2PSocket/SocketProvider.swift
+++ b/Data/P2PSocket/SocketProvider.swift
@@ -20,13 +20,6 @@ public final class SocketProvider: NSObject, SocketProvidable {
     public let resourceShared = PassthroughSubject<SharedResource, Never>()
     public let dataShared = PassthroughSubject<(Data, String), Never>()
     
-    public var connectedPeerIDs: [String] {
-        session.connectedPeers.compactMap { peerID in
-            MCPeerIDStorage.shared.peerIDByIdentifier.first {
-                $0.value.id == peerID
-            }?.key
-        }
-    }
 	private var isAllowedInvitation: Bool = true
 	private var invitationHandler: ((Bool, MCSession?) -> Void)?
 	

--- a/Data/P2PSocket/SocketProvider.swift
+++ b/Data/P2PSocket/SocketProvider.swift
@@ -133,10 +133,20 @@ public extension SocketProvider {
     func sendHashes(_ hashes: [String: String]) {
         guard let data = try? JSONSerialization.data(withJSONObject: hashes, options: []) else { return }
         try? session.send(data, toPeers: session.connectedPeers, with: .reliable)
+    func shareResource(
+        url localURL: URL,
+        resourceName: String,
+        to peerID: String,
+        completion: (((any Error)?) -> Void)? = nil
+    ) {
+        let uuid = UUID()
+        let nameWithUUID = [resourceName, uuid.uuidString].joined(separator: "/")
+        guard let mcPeerID = MCPeerIDStorage.shared.peerIDByIdentifier[peerID]?.id else { return }
         
-        for peer in session.connectedPeers {
-            syncFlags[peer] = false
-        }
+        session.sendResource(at: localURL,
+                             withName: nameWithUUID,
+                             toPeer: mcPeerID,
+                             withCompletionHandler: completion)
     }
 	  
     func shareResource(url localUrl: URL, resourceName: String) async throws {

--- a/Data/P2PSocket/SocketProvider.swift
+++ b/Data/P2PSocket/SocketProvider.swift
@@ -144,17 +144,14 @@ public extension SocketProvider {
     func sendResource(
         url localURL: URL,
         resourceName: String,
-        to peerID: String,
-        completion: (((any Error)?) -> Void)? = nil
-    ) {
+        to peerID: String) async {
         let uuid = UUID()
         let nameWithUUID = [resourceName, uuid.uuidString].joined(separator: "/")
         guard let mcPeerID = MCPeerIDStorage.shared.peerIDByIdentifier[peerID]?.id else { return }
         
         session.sendResource(at: localURL,
                              withName: nameWithUUID,
-                             toPeer: mcPeerID,
-                             withCompletionHandler: completion)
+                             toPeer: mcPeerID)
     }
 	  
     func sendResourceToAll(url localUrl: URL, resourceName: String) async throws {

--- a/Domain/Interfaces/RepositoryInterface/SharingVideoRepositoryInterface.swift
+++ b/Domain/Interfaces/RepositoryInterface/SharingVideoRepositoryInterface.swift
@@ -15,5 +15,5 @@ public protocol SharingVideoRepositoryInterface {
 
     func shareVideo(url: URL, resourceName: String) async throws
     func fetchVideos() -> [SharedVideo]
-    func synchronizeVideos()
+    func broadcastHashes()
 }

--- a/Domain/UseCase/VideoUseCase.swift
+++ b/Domain/UseCase/VideoUseCase.swift
@@ -39,7 +39,7 @@ public extension VideoUseCase {
     }
     
     func synchronizeVideos() {
-        repository.synchronizeVideos()
+        repository.broadcastHashes()
     }
 }
 


### PR DESCRIPTION
## 관련 이슈

- #56

## ✅ 완료 및 수정 내역

- SocketProvider에서 동기화 로직 분리 -> Synchronizer / Repository
- 해시 동기화 코드 구현

## 🛠️ 테스트 방법
- 시뮬레이터 2개로 테스트 했습니다. 디버깅이 잘 안되어서 나중에 메인 로직과 합쳐졌을 때 다시 테스트 해야 할 것 같습니다.<br>
- (시뮬레이터 2개가 통신 중 하나가 종료 후 다시 연결되었을 때 동영상 동기화가 되는지 테스트)

## 📝 리뷰 노트
```mermaid
sequenceDiagram
    loop [Until allSynced]
    A->>+B: 해시 값 전달: hash([String: String])
    A->>+C: 해시 값 전달: hash([String: String])
    A->>+D: 해시 값 전달: hash([String: String])
    B-->>-A: 해시 비교 정보 전달: hashMatch([fileName1: .missing])
    C-->>-A: 해시 비교 정보 전달: hashMatch([fileName2: .additional])
    D-->>-A: 해시 비교 정보 전달: hashMatch([fileName1: .missing, fileName2: .additional])
    Note right of A: sendSyncFlags: [B: false, C: false, D: false]<br/>receiveSyncFlags: [B: false, C: false, D: false]
    A->>+B: missing 파일 전달: shareResource(fileName1)
    A->>+C: additional 파일 요구: SyncMessage.request([fileName2])
    A->>+D: missing 파일 전달: shareResource(fileName1)
    A->>+D: additional 파일 요구: SyncMessage.request([fileName2])
    B-->>-A: sendResponse 전송
    Note right of A: sendSyncFlags: [B: true, C: false, D: false]<br/>receiveSyncFlags: [B: true, C: false, D: false]
    C-->>A: requested 파일 전달: shareResource(fileName2)
    C-->>-A: receiveResponse 전송
    Note right of A: sendSyncFlags: [B: true, C: true, D: false]<br/>receiveSyncFlags: [B: true, C: true, D: false]
    D-->>-A: sendResponse 전송
    Note right of A: sendSyncFlags: [B: true, C: true, D: true]<br/>receiveSyncFlags: [B: true, C: true, D: false]
    D-->>A: requested 파일 전달: shareResource(fileName2)
    D-->>-A: receiveResponse 전송
    Note right of A: sendSyncFlags: [B: true, C: true, D: true]<br/>receiveSyncFlags: [B: true, C: true, D: true]
    end
    A-->A: isSynchronized.send(Void)
    A-->B: completed
    B-->B: isSynchronized.send(Void)
    A-->C: completed
    C-->C: isSynchronized.send(Void)
    A-->D: completed
    D-->D: isSynchronized.send(Void)


    %% A -- hash([String: String]) --> C 
    %% A -- hash([String: String]) --> D
    %% B -- hash matching info (ex. [fileName1: .missing, fileName2: .additional]) --> B
```

### HashCondition
```swift
missing: 해당 파일이 없음
additional: 해당 파일이 추가적으로 존재함
```
해시 값을 비교하여 각 파일의 상태를 남깁니다.

### SyncMessage
```swift
hash([String: String]): 폴더 해시 정보를 피어들에게 전송합니다.
hashMatch([String: HashCondition]): 해시 비교 정보를 발신자에게 전송합니다.
request([String]): additional 파일들에 대해 전송을 요청합니다.
sendResponse: 전송받은 쪽에서 전송이 완료되었음을 알립니다.
receiveResponse: 받은 쪽에서 모든 수신이 완료되었음을 알립니다.
completed: 모든 동기화가 완료되고 다음 화면으로 넘어갈 수 있음을 알립니다.
```

### sendResource
기존 sendResource 로직에서 continuation leak이 발생해서 우선 주석처리 해두고 단순 전송으로 변경했습니다.<br>
단순 전송을 하더라도 편집 화면으로 넘어갈 때 동기화가 진행될 예정이므로 작동에는 문제 없지 않을까 싶습니다.... <br>
어떻게 할지 확인해주시면 반영하여 머지하도록 하겠습니다<br>
( + 그리고 receiveResource 주고받는 부분에서 뭔가 잘못 작성한 것 같은데 추후 수정하겠습니다.. 아직 테스트가 더 필요합니다 ㅠㅠ)

## 📱 스크린샷(선택)

https://github.com/user-attachments/assets/e24370a8-a7f3-42fe-a13d-156398ecff32

