### PR TITLE
[Feature/#77] 동영상 타임라인 드래그 앤 드롭 구현

### DIFF
--- a/Feature/Feature/SharedVideoEditView/SharedVideoEditViewController.swift
+++ b/Feature/Feature/SharedVideoEditView/SharedVideoEditViewController.swift
@@ -80,12 +80,12 @@ private extension SharedVideoEditViewController {
 
         output
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] output in
+            .sink(with: self, onReceive: { (owner, output) in
                 switch output {
                 case .timeLineDidChanged(let items):
-                    self?.reload(with: items)
+                    owner.reload(with: items)
                 }
-            }
+            })
             .store(in: &cancellables)
     }
 	

--- a/Feature/Feature/SharedVideoEditView/SharedVideoEditViewController.swift
+++ b/Feature/Feature/SharedVideoEditView/SharedVideoEditViewController.swift
@@ -183,6 +183,8 @@ private extension SharedVideoEditViewController {
         let dataSource = setupDataSource()
         self.videoTimelineDataSource = dataSource
         videoTimelineCollectionView.dataSource = dataSource
+        videoTimelineCollectionView.dragDelegate = self
+        videoTimelineCollectionView.dragInteractionEnabled = true
 
         videoTimelineCollectionView.register(
             VideoTimelineCollectionViewCell.self,
@@ -354,3 +356,16 @@ private extension SharedVideoEditViewController {
 }
 
 // MARK: - UICollectionViewDelegate
+
+extension SharedVideoEditViewController: UICollectionViewDragDelegate {
+    public func collectionView(
+        _ collectionView: UICollectionView,
+        itemsForBeginning session: any UIDragSession,
+        at indexPath: IndexPath
+    ) -> [UIDragItem] {
+        guard let item = videoTimelineDataSource.itemIdentifier(for: indexPath),
+              let jsonString = item.toJSONString() else { return [] }
+        let itemProvider = NSItemProvider(object: jsonString as NSString)
+        return [UIDragItem(itemProvider: itemProvider)]
+    }
+}

--- a/Feature/Feature/SharedVideoEditView/SharedVideoEditViewController.swift
+++ b/Feature/Feature/SharedVideoEditView/SharedVideoEditViewController.swift
@@ -58,8 +58,7 @@ public final class SharedVideoEditViewController: UIViewController {
 
 		setupUI()
         setupViewBinding()
-
-        loadInitialData()
+        
     }
     
     public override func viewWillAppear(_ animated: Bool) {
@@ -321,34 +320,6 @@ private extension SharedVideoEditViewController {
 
     func reload(with videos: [VideoTimelineItem]) {
         applySnapShot(with: videos)
-    }
-
-    // TEST 용 메서드 입니다.
-    func loadInitialData() {
-        let items = [
-            VideoTimelineItem(
-                thumbnailImage: Data(),
-                duration: "0:0"
-            ),
-            VideoTimelineItem(
-                thumbnailImage: Data(),
-                duration: "10:0"
-            ),
-            VideoTimelineItem(
-                thumbnailImage: Data(),
-                duration: "20:0"
-            ),
-            VideoTimelineItem(
-                thumbnailImage: Data(),
-                duration: "30:0"
-            ),
-            VideoTimelineItem(
-                thumbnailImage: Data(),
-                duration: "40:0"
-            )
-        ]
-
-        applySnapShot(with: items)
     }
 }
 

--- a/Feature/Feature/SharedVideoEditView/SharedVideoEditViewController.swift
+++ b/Feature/Feature/SharedVideoEditView/SharedVideoEditViewController.swift
@@ -392,20 +392,25 @@ extension SharedVideoEditViewController: UICollectionViewDropDelegate {
         performDropWith coordinator: any UICollectionViewDropCoordinator
     ) {
         guard let destinationIndexPath = coordinator.destinationIndexPath else { return }
+        var snapshot = videoTimelineDataSource.snapshot()
+        
+        let draggedItems: [VideoTimelineItem] = coordinator.items.compactMap { item in
+            if let sourceIndexPath = item.sourceIndexPath {
+                return snapshot.itemIdentifiers[sourceIndexPath.item]
+            }
+            return nil
+        }
+        
+        snapshot.deleteItems(draggedItems)
+        let targetIndex = destinationIndexPath.item
+        let currentItems = snapshot.itemIdentifiers
+        var updatedItems = currentItems
+        updatedItems.insert(contentsOf: draggedItems, at: targetIndex)
+        
+        applySnapShot(with: updatedItems)
         
         coordinator.items.forEach { item in
-            if let sourceIndexPath = item.sourceIndexPath {
-                collectionView.performBatchUpdates({
-                    var items = viewModel.items
-                    let movedItem = items.remove(at: sourceIndexPath.item)
-                    items.insert(movedItem, at: destinationIndexPath.item)
-                    viewModel.items = items
-                })
-                
-                reload(with: viewModel.items)
-                
-                coordinator.drop(item.dragItem, toItemAt: destinationIndexPath)
-            }
+            coordinator.drop(item.dragItem, toItemAt: destinationIndexPath)
         }
     }
 }

--- a/Feature/Feature/SharedVideoEditView/SharedVideoEditViewController.swift
+++ b/Feature/Feature/SharedVideoEditView/SharedVideoEditViewController.swift
@@ -59,6 +59,7 @@ public final class SharedVideoEditViewController: UIViewController {
 		setupUI()
         setupViewBinding()
         
+        input.send(.initialize)
     }
     
     public override func viewWillAppear(_ animated: Bool) {

--- a/Feature/Feature/SharedVideoEditView/SharedVideoEditViewController.swift
+++ b/Feature/Feature/SharedVideoEditView/SharedVideoEditViewController.swift
@@ -59,7 +59,7 @@ public final class SharedVideoEditViewController: UIViewController {
 		setupUI()
         setupViewBinding()
         
-        input.send(.initialize)
+        input.send(.setInitialState)
     }
     
     public override func viewWillAppear(_ animated: Bool) {

--- a/Feature/Feature/SharedVideoEditView/SharedVideoEditViewController.swift
+++ b/Feature/Feature/SharedVideoEditView/SharedVideoEditViewController.swift
@@ -80,7 +80,11 @@ private extension SharedVideoEditViewController {
 
         output
             .receive(on: DispatchQueue.main)
-            .sink { output in
+            .sink { [weak self] output in
+                switch output {
+                case .timeLineDidChanged(let items):
+                    self?.reload(with: items)
+                }
             }
             .store(in: &cancellables)
     }

--- a/Feature/Feature/SharedVideoEditView/View/CollectionView/VideoTimelineItem.swift
+++ b/Feature/Feature/SharedVideoEditView/View/CollectionView/VideoTimelineItem.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct VideoTimelineItem: Codable, Hashable {
+struct VideoTimelineItem: Codable, Hashable {
     let identifier = UUID()
     let thumbnailImage: Data
     let duration: String

--- a/Feature/Feature/SharedVideoEditView/View/CollectionView/VideoTimelineItem.swift
+++ b/Feature/Feature/SharedVideoEditView/View/CollectionView/VideoTimelineItem.swift
@@ -7,12 +7,27 @@
 
 import Foundation
 
-public struct VideoTimelineItem: Hashable {
+public struct VideoTimelineItem: Codable, Hashable {
     let identifier = UUID()
     let thumbnailImage: Data
     let duration: String
 
     public func hash(into hasher: inout Hasher) {
         hasher.combine(identifier)
+    }
+}
+
+extension VideoTimelineItem {
+    static func fromJSONString(_ jsonString: String) -> VideoTimelineItem? {
+        let decoder = JSONDecoder()
+        guard let jsonData = jsonString.data(using: .utf8),
+              let item = try? decoder.decode(VideoTimelineItem.self, from: jsonData) else { return nil }
+        return item
+    }
+    
+    func toJSONString() -> String? {
+        let encoder = JSONEncoder()
+        guard let jsonData = try? encoder.encode(self) else { return nil }
+        return String(data: jsonData, encoding: .utf8)
     }
 }

--- a/Feature/Feature/SharedVideoEditView/ViewModel/SharedVideoEditViewInput.swift
+++ b/Feature/Feature/SharedVideoEditView/ViewModel/SharedVideoEditViewInput.swift
@@ -7,4 +7,6 @@
 
 import Foundation
 
-enum SharedVideoEditViewInput { }
+enum SharedVideoEditViewInput {
+    case initialize
+}

--- a/Feature/Feature/SharedVideoEditView/ViewModel/SharedVideoEditViewInput.swift
+++ b/Feature/Feature/SharedVideoEditView/ViewModel/SharedVideoEditViewInput.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 enum SharedVideoEditViewInput {
-    case initialize
+    case setInitialState
 }

--- a/Feature/Feature/SharedVideoEditView/ViewModel/SharedVideoEditViewModel.swift
+++ b/Feature/Feature/SharedVideoEditView/ViewModel/SharedVideoEditViewModel.swift
@@ -27,6 +27,8 @@ public final class SharedVideoEditViewModel {
             guard let self else { return }
             switch input {
             case .initialize:
+            // 테스트 셋업으로 초기화합니다.
+            case .setInitialState:
                 let initialItems = [
                     VideoTimelineItem(
                         thumbnailImage: Data(),

--- a/Feature/Feature/SharedVideoEditView/ViewModel/SharedVideoEditViewModel.swift
+++ b/Feature/Feature/SharedVideoEditView/ViewModel/SharedVideoEditViewModel.swift
@@ -15,8 +15,6 @@ public final class SharedVideoEditViewModel {
     
     private var output = PassthroughSubject<Output, Never>()
     private var cancellables: Set<AnyCancellable> = []
-    
-    var items: [VideoTimelineItem] = []
 
     public init() {
         setupBind()
@@ -26,7 +24,6 @@ public final class SharedVideoEditViewModel {
         input.sink { [weak self] input in
             guard let self else { return }
             switch input {
-            case .initialize:
             // 테스트 셋업으로 초기화합니다.
             case .setInitialState:
                 let initialItems = [
@@ -51,7 +48,6 @@ public final class SharedVideoEditViewModel {
                         duration: "40:0"
                     )
                 ]
-                self.items = initialItems
                 output.send(.timeLineDidChanged(items: initialItems))
             }
         }

--- a/Feature/Feature/SharedVideoEditView/ViewModel/SharedVideoEditViewModel.swift
+++ b/Feature/Feature/SharedVideoEditView/ViewModel/SharedVideoEditViewModel.swift
@@ -21,8 +21,7 @@ public final class SharedVideoEditViewModel {
     }
     
     func transform(_ input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
-        input.sink { [weak self] input in
-            guard let self else { return }
+        input.sink(with: self) { owner, input in
             switch input {
             // 테스트 셋업으로 초기화합니다.
             case .setInitialState:
@@ -48,7 +47,7 @@ public final class SharedVideoEditViewModel {
                         duration: "40:0"
                     )
                 ]
-                output.send(.timeLineDidChanged(items: initialItems))
+                owner.output.send(.timeLineDidChanged(items: initialItems))
             }
         }
         .store(in: &cancellables)

--- a/Feature/Feature/SharedVideoEditView/ViewModel/SharedVideoEditViewModel.swift
+++ b/Feature/Feature/SharedVideoEditView/ViewModel/SharedVideoEditViewModel.swift
@@ -15,13 +15,43 @@ public final class SharedVideoEditViewModel {
     
     private var output = PassthroughSubject<Output, Never>()
     private var cancellables: Set<AnyCancellable> = []
+    
+    var items: [VideoTimelineItem] = []
 
     public init() {
         setupBind()
     }
     
     func transform(_ input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
-        input.sink { _ in
+        input.sink { [weak self] input in
+            guard let self else { return }
+            switch input {
+            case .initialize:
+                let initialItems = [
+                    VideoTimelineItem(
+                        thumbnailImage: Data(),
+                        duration: "0:0"
+                    ),
+                    VideoTimelineItem(
+                        thumbnailImage: Data(),
+                        duration: "10:0"
+                    ),
+                    VideoTimelineItem(
+                        thumbnailImage: Data(),
+                        duration: "20:0"
+                    ),
+                    VideoTimelineItem(
+                        thumbnailImage: Data(),
+                        duration: "30:0"
+                    ),
+                    VideoTimelineItem(
+                        thumbnailImage: Data(),
+                        duration: "40:0"
+                    )
+                ]
+                self.items = initialItems
+                output.send(.timeLineDidChanged(items: initialItems))
+            }
         }
         .store(in: &cancellables)
 

--- a/Feature/Feature/SharedVideoEditView/ViewModel/SharedVideoEditViewOutput.swift
+++ b/Feature/Feature/SharedVideoEditView/ViewModel/SharedVideoEditViewOutput.swift
@@ -7,4 +7,6 @@
 
 import Foundation
 
-enum SharedVideoEditViewOutput { }
+enum SharedVideoEditViewOutput {
+    case timeLineDidChanged(items: [VideoTimelineItem])
+}


### PR DESCRIPTION
## 관련 이슈

- #77 

## ✅ 완료 및 수정 내역

- DragDelegate, DropDelegate 구현
- ViewModel과 초기화 로직 연결

## 🛠️ 테스트 방법

- SharedVideoEditViewController를 루트로 하여 테스트 했습니다.

## 📝 리뷰 노트
ViewModel과 연결하면서 드롭 시 데이터 업데이트를 Input으로 보내 ViewModel에서 업데이트를 진행하려고 했으나 이 경우 애니메이션 오류가 발생합니다.<br>

### 의도한 동작
```swift
drop을 통해 이동하려는 인덱스와 아이템 파악 -> 
ViewModel Input으로 전달 -> 
ViewModel transform에서 items 배열 조작 -> 
결과를 output으로 방출 -> 
output에 따른 컬렉션 뷰 반영 및 애니메이션
```

### 결과 동작

https://github.com/user-attachments/assets/7fe77d7f-dc7d-4466-91b7-7ba40477142b

```swift
drop으로 인한 애니메이션이 우선 진행 ->
이후 업데이트된 output에 대한 애니메이션 진행
(이런식으로 2번에 걸친 애니메이션이 발생하여 자연스럽게 보이지 않습니다.)
```

따라서 현재는 ViewModel을 통하지 않고 ViewController에서 직접 업데이트 합니다.
이 부분에서 어떻게 처리해야 할지? 조언이 필요합니다. 

<br>

## 📱 스크린샷(선택)

https://github.com/user-attachments/assets/2a53762b-393d-4902-ad83-92fb719b78d3



