### PR TITLE
[Feature/#88] 타임라인 프리뷰 및 파일 저장 기능 구현

### DIFF
--- a/Feature/Feature.xcodeproj/project.pbxproj
+++ b/Feature/Feature.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 				MainViewController.swift,
 				PresentationModel/VideoPresentationModel.swift,
 				SharedVideoEditView/SharedVideoEditViewController.swift,
+				SharedVideoEditView/VideoMerger/VideoMerger.swift,
 				SharedVideoEditView/View/CollectionView/VideoTimelineCollectionViewCell.swift,
 				SharedVideoEditView/View/CollectionView/VideoTimelineDataSource.swift,
 				SharedVideoEditView/View/CollectionView/VideoTimelineItem.swift,

--- a/Feature/Feature/SharedVideoEditView/VideoMerger/VideoMerger.swift
+++ b/Feature/Feature/SharedVideoEditView/VideoMerger/VideoMerger.swift
@@ -8,4 +8,22 @@
 import AVFoundation
 import Entity
 
-enum VideoMerger { }
+enum VideoMerger {
+    private static func adoptAlphaInstruction(
+        _ layerInstruction: AVMutableVideoCompositionLayerInstruction,
+        currentTime: CMTime,
+        duration: CMTime
+    ) -> AVMutableVideoCompositionInstruction {
+        layerInstruction.setOpacity(0.0, at: .zero)
+        layerInstruction.setOpacity(1.0, at: currentTime)
+        
+        let endTime = CMTimeAdd(currentTime, duration)
+        layerInstruction.setOpacity(0.0, at: endTime)
+        
+        let instruction = AVMutableVideoCompositionInstruction()
+        instruction.timeRange = CMTimeRange(start: currentTime, duration: duration)
+        instruction.layerInstructions = [layerInstruction]
+        
+        return instruction
+    }
+}

--- a/Feature/Feature/SharedVideoEditView/VideoMerger/VideoMerger.swift
+++ b/Feature/Feature/SharedVideoEditView/VideoMerger/VideoMerger.swift
@@ -8,7 +8,7 @@
 import AVFoundation
 import Entity
 
-enum VideoMerger {
+public enum VideoMerger {
     private enum Constants {
         static let scaleSecond: Int32 = 600
         static let defaultFrameRate: Int32 = 30
@@ -30,10 +30,10 @@ enum VideoMerger {
         let resultVideoSize = try await firstVideoTrack.load(.naturalSize)
         
         let (composition, videoComposition) = try await merge(videos, size: resultVideoSize)
-
+        
         return try await export(composition: composition, videoComposition: videoComposition, outputURL: outputURL)
     }
-
+    
     /// 전달받은 비디오 목록을 병합한 결과에 대한 AVPlayerItem을 반환합니다.
     static func preview(
         videos: [Video],
@@ -44,7 +44,10 @@ enum VideoMerger {
         avItem.videoComposition = videoComposition
         return avItem
     }
+}
 
+// MARK: - Private Methods
+private extension VideoMerger {
     private static func merge(
         _ videos: [Video],
         size resultSize: CGSize,
@@ -81,7 +84,7 @@ enum VideoMerger {
                 .concatenating(CGAffineTransform(scaleX: scale, y: scale))
                 .concatenating(CGAffineTransform(translationX: center.x, y: center.y))
             layerInstruction.setTransform(transform, at: .zero)
-
+            
             let instruction = adoptAlphaInstruction(
                 layerInstruction,
                 currentTime: currentTime,
@@ -100,8 +103,8 @@ enum VideoMerger {
         
         return (composition, videoComposition)
     }
-
-    private static func export(
+    
+    static func export(
         composition: AVMutableComposition,
         videoComposition: AVMutableVideoComposition,
         outputURL: URL
@@ -112,7 +115,7 @@ enum VideoMerger {
         }
         
         exporter.videoComposition = videoComposition
-
+        
         if #available(iOS 18, *) {
             return try await exporter.export(to: outputURL, as: .mp4)
         } else {
@@ -134,8 +137,8 @@ enum VideoMerger {
             }
         }
     }
-
-    private static func addTrack(
+    
+    static func addTrack(
         to composition: AVMutableComposition,
         withMediaType mediaType: AVMediaType
     ) async throws -> AVMutableCompositionTrack {
@@ -145,8 +148,8 @@ enum VideoMerger {
         }
         return track
     }
-
-    private static func loadTrack(
+    
+    static func loadTrack(
         from asset: AVAsset,
         withMediaType mediaType: AVMediaType
     ) async throws -> AVAssetTrack {
@@ -156,17 +159,17 @@ enum VideoMerger {
         }
         return track
     }
-
-
-private static func scaleToAspectFit(with videoSize: CGSize, to resultVideoSize: CGSize) -> CGFloat {
-    let scaleX = resultVideoSize.width / videoSize.width
-    let scaleY = resultVideoSize.height / videoSize.height
-    let scale = min(scaleX, scaleY)
     
-    return scale
-}
-
-    private static func moveToCenter(
+    
+    static func scaleToAspectFit(with videoSize: CGSize, to resultVideoSize: CGSize) -> CGFloat {
+        let scaleX = resultVideoSize.width / videoSize.width
+        let scaleY = resultVideoSize.height / videoSize.height
+        let scale = min(scaleX, scaleY)
+        
+        return scale
+    }
+    
+    static func moveToCenter(
         with videoSize: CGSize,
         to resultVideoSize: CGSize,
         scale: CGFloat
@@ -179,7 +182,7 @@ private static func scaleToAspectFit(with videoSize: CGSize, to resultVideoSize:
         return CGPoint(x: translationX, y: translationY)
     }
     
-    private static func adoptAlphaInstruction(
+    static func adoptAlphaInstruction(
         _ layerInstruction: AVMutableVideoCompositionLayerInstruction,
         currentTime: CMTime,
         duration: CMTime

--- a/Feature/Feature/SharedVideoEditView/VideoMerger/VideoMerger.swift
+++ b/Feature/Feature/SharedVideoEditView/VideoMerger/VideoMerger.swift
@@ -13,6 +13,26 @@ enum VideoMerger {
         static let scaleSecond: Int32 = 600
         static let defaultFrameRate: Int32 = 30
     }
+    
+    /// 전달받은 URL로 비디오 목록을 병합한 결과를 저장합니다.
+    static func mergeWithSave(
+        _ videos: [Video],
+        outputURL: URL,
+        frameRate: Int32 = Constants.defaultFrameRate
+    ) async throws {
+        guard let firstVideo = videos.first
+        else {
+            throw NSError(domain: "NoVideos", code: -1, userInfo: nil)
+        }
+        
+        let firstAsset = AVURLAsset(url: firstVideo.url)
+        let firstVideoTrack = try await loadTrack(from: firstAsset, withMediaType: .video)
+        let resultVideoSize = try await firstVideoTrack.load(.naturalSize)
+        
+        let (composition, videoComposition) = try await merge(videos, size: resultVideoSize)
+
+        return try await export(composition: composition, videoComposition: videoComposition, outputURL: outputURL)
+    }
 
     /// 전달받은 비디오 목록을 병합한 결과에 대한 AVPlayerItem을 반환합니다.
     static func preview(

--- a/Feature/Feature/SharedVideoEditView/VideoMerger/VideoMerger.swift
+++ b/Feature/Feature/SharedVideoEditView/VideoMerger/VideoMerger.swift
@@ -9,6 +9,67 @@ import AVFoundation
 import Entity
 
 enum VideoMerger {
+    private enum Constants {
+        static let scaleSecond: Int32 = 600
+        static let defaultFrameRate: Int32 = 30
+    }
+
+    private static func merge(
+        _ videos: [Video],
+        size resultSize: CGSize,
+        frameRate: Int32 = Constants.defaultFrameRate
+    ) async throws -> (AVMutableComposition, AVMutableVideoComposition){
+        let composition = AVMutableComposition()
+        var currentTime = CMTime.zero
+        
+        var layerInstructions: [AVMutableVideoCompositionInstruction] = []
+        
+        for video in videos {
+            let asset = AVURLAsset(url: video.url)
+            
+            let assetVideoTrack = try await loadTrack(from: asset, withMediaType: .video)
+            let assetAudioTrack = try await loadTrack(from: asset, withMediaType: .audio)
+            
+            let startTime = CMTime(seconds: video.startTime, preferredTimescale: Constants.scaleSecond)
+            let duration = CMTime(seconds: video.endTime - video.startTime, preferredTimescale: Constants.scaleSecond)
+            let timeRange = CMTimeRange(start: startTime, duration: duration)
+            
+            let videoTrack = try await addTrack(to: composition, withMediaType: .video)
+            let audioTrack = try await addTrack(to: composition, withMediaType: .audio)
+            
+            try videoTrack.insertTimeRange(timeRange, of: assetVideoTrack, at: currentTime)
+            try audioTrack.insertTimeRange(timeRange, of: assetAudioTrack, at: currentTime)
+            
+            let layerInstruction = AVMutableVideoCompositionLayerInstruction(assetTrack: videoTrack)
+            let videoSize = try await assetVideoTrack.load(.naturalSize)
+            
+            let scale = scaleToAspectFit(with: videoSize, to: resultSize)
+            let center = moveToCenter(with: videoSize, to: resultSize, scale: scale)
+            
+            let transform = try await assetVideoTrack.load(.preferredTransform)
+                .concatenating(CGAffineTransform(scaleX: scale, y: scale))
+                .concatenating(CGAffineTransform(translationX: center.x, y: center.y))
+            layerInstruction.setTransform(transform, at: .zero)
+
+            let instruction = adoptAlphaInstruction(
+                layerInstruction,
+                currentTime: currentTime,
+                duration: duration
+            )
+            
+            layerInstructions.append(instruction)
+            currentTime = CMTimeAdd(currentTime, duration)
+        }
+        
+        // 비디오 컴포지션 설정
+        let videoComposition = AVMutableVideoComposition()
+        videoComposition.frameDuration = CMTime(value: 1, timescale: frameRate)
+        videoComposition.renderSize = resultSize
+        videoComposition.instructions =  layerInstructions
+        
+        return (composition, videoComposition)
+    }
+
     private static func export(
         composition: AVMutableComposition,
         videoComposition: AVMutableVideoComposition,

--- a/Feature/Feature/SharedVideoEditView/VideoMerger/VideoMerger.swift
+++ b/Feature/Feature/SharedVideoEditView/VideoMerger/VideoMerger.swift
@@ -9,6 +9,14 @@ import AVFoundation
 import Entity
 
 enum VideoMerger {
+private static func scaleToAspectFit(with videoSize: CGSize, to resultVideoSize: CGSize) -> CGFloat {
+    let scaleX = resultVideoSize.width / videoSize.width
+    let scaleY = resultVideoSize.height / videoSize.height
+    let scale = min(scaleX, scaleY)
+    
+    return scale
+}
+
     private static func moveToCenter(
         with videoSize: CGSize,
         to resultVideoSize: CGSize,

--- a/Feature/Feature/SharedVideoEditView/VideoMerger/VideoMerger.swift
+++ b/Feature/Feature/SharedVideoEditView/VideoMerger/VideoMerger.swift
@@ -9,6 +9,17 @@ import AVFoundation
 import Entity
 
 enum VideoMerger {
+    private static func addTrack(
+        to composition: AVMutableComposition,
+        withMediaType mediaType: AVMediaType
+    ) async throws -> AVMutableCompositionTrack {
+        guard let track = composition.addMutableTrack(withMediaType: mediaType, preferredTrackID: kCMPersistentTrackID_Invalid)
+        else {
+            throw NSError(domain: "CannotCreateVideoTrack", code: -2, userInfo: nil)
+        }
+        return track
+    }
+
     private static func loadTrack(
         from asset: AVAsset,
         withMediaType mediaType: AVMediaType

--- a/Feature/Feature/SharedVideoEditView/VideoMerger/VideoMerger.swift
+++ b/Feature/Feature/SharedVideoEditView/VideoMerger/VideoMerger.swift
@@ -9,6 +9,19 @@ import AVFoundation
 import Entity
 
 enum VideoMerger {
+    private static func moveToCenter(
+        with videoSize: CGSize,
+        to resultVideoSize: CGSize,
+        scale: CGFloat
+    ) -> CGPoint {
+        let scaledWidth = videoSize.width * scale
+        let scaledHeight = videoSize.height * scale
+        let translationX = (resultVideoSize.width - scaledWidth) / 2
+        let translationY = (resultVideoSize.height - scaledHeight) / 2
+        
+        return CGPoint(x: translationX, y: translationY)
+    }
+    
     private static func adoptAlphaInstruction(
         _ layerInstruction: AVMutableVideoCompositionLayerInstruction,
         currentTime: CMTime,

--- a/Feature/Feature/SharedVideoEditView/VideoMerger/VideoMerger.swift
+++ b/Feature/Feature/SharedVideoEditView/VideoMerger/VideoMerger.swift
@@ -53,7 +53,7 @@ private extension VideoMerger {
         size resultSize: CGSize,
         frameRate: Int32 = Constants.defaultFrameRate
     ) async throws -> (AVMutableComposition, AVMutableVideoComposition) {
-        let orderdVideos = videosvideos.sorted { $0.index < $0.index }
+        let orderdVideos = videos.sorted { $0.index < $1.index }
         let composition = AVMutableComposition()
         var currentTime = CMTime.zero
         
@@ -143,7 +143,10 @@ private extension VideoMerger {
         to composition: AVMutableComposition,
         withMediaType mediaType: AVMediaType
     ) async throws -> AVMutableCompositionTrack {
-        guard let track = composition.addMutableTrack(withMediaType: mediaType, preferredTrackID: kCMPersistentTrackID_Invalid)
+        guard let track = composition.addMutableTrack(
+            withMediaType: mediaType,
+            preferredTrackID: kCMPersistentTrackID_Invalid
+        )
         else {
             throw NSError(domain: "CannotCreateVideoTrack", code: -2, userInfo: nil)
         }

--- a/Feature/Feature/SharedVideoEditView/VideoMerger/VideoMerger.swift
+++ b/Feature/Feature/SharedVideoEditView/VideoMerger/VideoMerger.swift
@@ -1,0 +1,11 @@
+//
+//  VideoMerger.swift
+//  Feature
+//
+//  Created by Yune gim on 12/4/24.
+//
+
+import AVFoundation
+import Entity
+
+enum VideoMerger { }

--- a/Feature/Feature/SharedVideoEditView/VideoMerger/VideoMerger.swift
+++ b/Feature/Feature/SharedVideoEditView/VideoMerger/VideoMerger.swift
@@ -52,13 +52,14 @@ private extension VideoMerger {
         _ videos: [Video],
         size resultSize: CGSize,
         frameRate: Int32 = Constants.defaultFrameRate
-    ) async throws -> (AVMutableComposition, AVMutableVideoComposition){
+    ) async throws -> (AVMutableComposition, AVMutableVideoComposition) {
+        let orderdVideos = videosvideos.sorted { $0.index < $0.index }
         let composition = AVMutableComposition()
         var currentTime = CMTime.zero
         
         var layerInstructions: [AVMutableVideoCompositionInstruction] = []
         
-        for video in videos {
+        for video in orderdVideos {
             let asset = AVURLAsset(url: video.url)
             
             let assetVideoTrack = try await loadTrack(from: asset, withMediaType: .video)
@@ -159,7 +160,6 @@ private extension VideoMerger {
         }
         return track
     }
-    
     
     static func scaleToAspectFit(with videoSize: CGSize, to resultVideoSize: CGSize) -> CGFloat {
         let scaleX = resultVideoSize.width / videoSize.width

--- a/Feature/Feature/SharedVideoEditView/VideoMerger/VideoMerger.swift
+++ b/Feature/Feature/SharedVideoEditView/VideoMerger/VideoMerger.swift
@@ -9,6 +9,18 @@ import AVFoundation
 import Entity
 
 enum VideoMerger {
+    private static func loadTrack(
+        from asset: AVAsset,
+        withMediaType mediaType: AVMediaType
+    ) async throws -> AVAssetTrack {
+        guard let track = try await asset.loadTracks(withMediaType: mediaType).first
+        else {
+            throw NSError(domain: "InvalidVideoTracks", code: -2, userInfo: nil)
+        }
+        return track
+    }
+
+
 private static func scaleToAspectFit(with videoSize: CGSize, to resultVideoSize: CGSize) -> CGFloat {
     let scaleX = resultVideoSize.width / videoSize.width
     let scaleY = resultVideoSize.height / videoSize.height

--- a/Feature/Feature/SharedVideoEditView/VideoMerger/VideoMerger.swift
+++ b/Feature/Feature/SharedVideoEditView/VideoMerger/VideoMerger.swift
@@ -14,6 +14,17 @@ enum VideoMerger {
         static let defaultFrameRate: Int32 = 30
     }
 
+    /// 전달받은 비디오 목록을 병합한 결과에 대한 AVPlayerItem을 반환합니다.
+    static func preview(
+        videos: [Video],
+        size previewSize: CGSize
+    ) async throws -> AVPlayerItem {
+        let (composition, videoComposition) = try await merge(videos, size: previewSize)
+        let avItem = await AVPlayerItem(asset: composition)
+        avItem.videoComposition = videoComposition
+        return avItem
+    }
+
     private static func merge(
         _ videos: [Video],
         size resultSize: CGSize,


### PR DESCRIPTION
## 관련 이슈

- #88 

## ✅ 완료 및 수정 내역

- 동영상 합병을 수행하는 VideoMerger 선언
- 동영상 목록을 병합한 동영상에 대해 프리뷰를 제공하는 기능 구현
- 동영상 목록을 병합한 동영상을 파일로 내보내는 기능 구현

## 🛠️ 테스트 방법

- 실제 URL에서 파일을 불러올 수 있어야 하므로 직접 실행하여 테스트 가능합니다.
```swift
let videos  = [
    Video(url: url0, name: "Video 1", index: 0, author: "Author 1", duration: 5, startTime: 0, endTime: 5),
    Video(url: url1, name: "Video 2", index: 1, author: "Author 2", duration: 15, startTime: 30, endTime: 45)
]
// 프리뷰 제공
let playerItem = try await VideoExporter.preview(videos: videos, size: .init(width: 393, height: 307))
let videoView = VideoPlayerView(playerItem: playerItem)
// 타임라인 저장
let outputURL = FileManager.default.temporaryDirectory
    .appendingPathComponent(UUID().uuidString)
    .appendingPathExtension("mp4")
try await VideoExporter.mergeWithSave(videos, outputURL: outputURL)
```

## 📝 리뷰 노트

합병의 시작은 AVMutableComposition에 비디오와 오디오 트랙을 추가하는 것 입니다.
하나의 트랙은 마치 트리처럼 여러 트랙을 가질 수 있습니다. (1:N)
이때 각 비디오 트랙은 기본적으로 불투명하며, 따라서 자신의 재생 시작과 종료 시간에 맞춰 투명도를 조절해야 합니다.
- adoptAlphaInstruction() 로 수행하고 있음

이 외에 여러 비디오를 병합할때 문제되는 점은 다음 3가지가 있습니다.
1. 어느 기준으로 전체 동영상 해상도를 결정할 지 결정돼있지 않은 문제
2. 기본적으로 좌측 정렬인 문제
3. 각 동영상의 해상도가 모두 다른 문제

1번 문제는 프리뷰일때에는 뷰의 크기를, 출력할 때에는 첫번째 동영상의 크기를 기준으로 비디오를 병합합니다.
2번, 3번 문제는 CGAffineTransform을 사용해 항등변환하여 크기와 위치를 조절합니다.

아직 AVFoundation이 Concurrency를 완벽히 지원하지 않아 Sendable 관련 경고가 있습니다.
프레임워크의 문제로 현재로서는 해결하기 어렵습니다.

## 📱 스크린샷(선택)
https://github.com/user-attachments/assets/3dd9e8a3-d683-4240-9da0-a8c3b33a392d
