### PR TITLE
[Feature/#83] 동영상 리스트 정보가 정상적으로 뜨게 변경 및 타임라인 뷰와 연결

### DIFF
--- a/App/App/SceneDelegate.swift
+++ b/App/App/SceneDelegate.swift
@@ -90,19 +90,21 @@ extension SceneDelegate {
         )
         
         DIContainer.shared.register(
-            type: SharingVideoUseCaseInterface.self,
+            type: VideoUseCase.self,
             instance: VideoUseCase(
                 sharingVideoRepository: DIContainer.shared.resolve(type: SharingVideoRepositoryInterface.self),
                 editVideoRepository: DIContainer.shared.resolve(type: EditVideoRepositoryInterface.self)
             )
         )
+        
+        DIContainer.shared.register(
+            type: SharingVideoUseCaseInterface.self,
+            instance: DIContainer.shared.resolve(type: VideoUseCase.self)
+        )
 
         DIContainer.shared.register(
             type: EditVideoUseCaseInterface.self,
-            instance: VideoUseCase(
-                sharingVideoRepository: DIContainer.shared.resolve(type: SharingVideoRepositoryInterface.self),
-                editVideoRepository: DIContainer.shared.resolve(type: EditVideoRepositoryInterface.self)
-            )
+            instance: DIContainer.shared.resolve(type: VideoUseCase.self)
         )
     }
 

--- a/Data/Data/SharingVideoRepository.swift
+++ b/Data/Data/SharingVideoRepository.swift
@@ -69,6 +69,8 @@ public extension SharingVideoRepository {
     }
     
     func broadcastHashes() {
+        guard !socketProvider.connectedPeers().isEmpty else { return isSynchronized.send(()) }
+        
         let collectedHashes = synchronizer.collectHashes()
         let hashMessage = SyncMessage.hash(collectedHashes)
         
@@ -83,6 +85,10 @@ public extension SharingVideoRepository {
             }
         
         hasMismatch = false
+    }
+    
+    func authorInformation() -> String {
+        socketProvider.displayName
     }
 }
 

--- a/Domain/Interfaces/RepositoryInterface/SharingVideoRepositoryInterface.swift
+++ b/Domain/Interfaces/RepositoryInterface/SharingVideoRepositoryInterface.swift
@@ -15,4 +15,5 @@ public protocol SharingVideoRepositoryInterface {
 
     func shareVideo(url: URL, resourceName: String)
     func broadcastHashes()
+    func authorInformation() -> String
 }

--- a/Domain/UseCase/VideoUseCase.swift
+++ b/Domain/UseCase/VideoUseCase.swift
@@ -40,6 +40,14 @@ extension VideoUseCase: SharingVideoUseCaseInterface {
 	}
 	
 	public func shareVideo(_ url: URL, resourceName: String) {
+        sharedVideos.append(
+            SharedVideo(
+                localUrl: url,
+                name: resourceName,
+                author: sharingVideoRepository.authorInformation()
+            )
+        )
+        
 		sharingVideoRepository.shareVideo(url: url, resourceName: resourceName)
 	}
 	

--- a/Feature/Feature/SharedVideoEditView/SharedVideoEditViewController.swift
+++ b/Feature/Feature/SharedVideoEditView/SharedVideoEditViewController.swift
@@ -61,11 +61,6 @@ public final class SharedVideoEditViewController: UIViewController {
         
         input.send(.viewDidLoad)
     }
-    
-    public override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        navigationController?.setNavigationBarHidden(true, animated: true)
-    }
 }
 
 // MARK: - Binding
@@ -403,7 +398,11 @@ extension SharedVideoEditViewController: UICollectionViewDelegate {
         _ collectionView: UICollectionView,
         didSelectItemAt indexPath: IndexPath
     ) {
-        guard let selectedItem = videoTimelineDataSource.itemIdentifier(for: indexPath) else { return }
+        guard let selectedItem = videoTimelineDataSource.itemIdentifier(for: indexPath),
+              let selectedCell = collectionView.cellForItem(at: indexPath)
+        else { return }
+        
+        selectedCell.isSelected = true
         videoPlayerView.replaceVideo(url: selectedItem.url)
         input.send(.timelineCellDidTap(url: selectedItem.url))
     }

--- a/Feature/Feature/SharedVideoEditView/View/CollectionView/VideoTimelineCollectionViewCell.swift
+++ b/Feature/Feature/SharedVideoEditView/View/CollectionView/VideoTimelineCollectionViewCell.swift
@@ -18,6 +18,12 @@ final class VideoTimelineCollectionViewCell: UICollectionViewCell {
     private let thumbnailImageView = UIImageView()
     private let durationView = UIView()
     private let durationLabel = UILabel()
+    
+    override var isSelected: Bool {
+        didSet {
+            updateBorder()
+        }
+    }
 
     // MARK: - Initializer
 
@@ -64,15 +70,16 @@ private extension VideoTimelineCollectionViewCell {
     }
 
     func setupViewAttributes() {
+        layer.cornerRadius = ThumbnailImageViewConstants.cornerRadius
+        layer.masksToBounds = true
+        
         setupThumbnailImageView()
         setupDurationView()
         setupDurationLabel()
     }
 
     func setupThumbnailImageView() {
-        thumbnailImageView.layer.cornerRadius = ThumbnailImageViewConstants.cornerRadius
         thumbnailImageView.backgroundColor = .systemGray6
-        thumbnailImageView.clipsToBounds = true
         thumbnailImageView.contentMode = .scaleAspectFill
     }
 
@@ -111,5 +118,12 @@ private extension VideoTimelineCollectionViewCell {
         durationLabel.snp.makeConstraints { make in
             make.edges.equalToSuperview().inset(DurationLabelConstants.edgesInset)
         }
+    }
+}
+
+private extension VideoTimelineCollectionViewCell {
+    func updateBorder() {
+        layer.borderWidth = isSelected ? 2 : 0
+        layer.borderColor = isSelected ? UIColor.white.cgColor : UIColor.clear.cgColor
     }
 }

--- a/Feature/Feature/SharedVideoEditView/View/VideoPlayer/VideoPlayerView.swift
+++ b/Feature/Feature/SharedVideoEditView/View/VideoPlayer/VideoPlayerView.swift
@@ -117,7 +117,7 @@ private extension VideoPlayerView {
     
     func setupPlayPauseButton() {
         var buttonConfigurarion = UIButton.Configuration.plain()
-        buttonConfigurarion.image = UIImage(systemName: "pause.circle")
+        buttonConfigurarion.image = UIImage(systemName: "play.circle.fill")
         buttonConfigurarion.preferredSymbolConfigurationForImage =  UIImage.SymbolConfiguration(pointSize: 30)
         buttonConfigurarion.baseForegroundColor = .white
         playPauseButton.configuration = buttonConfigurarion
@@ -134,6 +134,13 @@ private extension VideoPlayerView {
 // MARK: - Binding
 private extension VideoPlayerView {
 	func setupViewBinding() {
+        NotificationCenter.default
+            .publisher(for: .AVPlayerItemDidPlayToEndTime, object: player.currentItem)
+            .sink(with: self) { owner, _ in
+                owner.handleVideoCompletion()
+            }
+            .store(in: &cancellables)
+        
 		// Thanks to LURKS02
 		playPauseButton.publisher(for: .touchUpInside)
 			.receive(on: DispatchQueue.main)
@@ -206,4 +213,13 @@ private extension VideoPlayerView {
 		let seekTime = CMTime(seconds: newTime, preferredTimescale: 1)
 		player.seek(to: seekTime)
 	}
+    
+    func handleVideoCompletion() {
+            seekingSlider.value = 100
+
+            let image = UIImage(systemName: "play.circle.fill")
+            playPauseButton.setImage(image, for: .normal)
+
+            player.seek(to: .zero)
+        }
 }

--- a/Feature/Feature/VideoListView/VideoListViewController.swift
+++ b/Feature/Feature/VideoListView/VideoListViewController.swift
@@ -59,6 +59,7 @@ public final class VideoListViewController: UIViewController {
 // MARK: - Setting
 private extension VideoListViewController {
     func setupViewAttributes() {
+        navigationController?.isNavigationBarHidden = true
         view.backgroundColor = .black
         collectionView.register(VideoListCollectionViewCell.self,
                                 forCellWithReuseIdentifier: VideoListCollectionViewCell.identifier)


### PR DESCRIPTION
## 관련 이슈

- #83 

## ✅ 완료 및 수정 내역

- 동영상 리스트에서 author 등의 정보가 문제 없이 보이도록 수정
- 실제 동영상을 타임라인에 연결

## 🛠️ 테스트 방법

- 애플리케이션 첫 화면부터 실행하여 기능에 이상이 없는지 순차적으로 테스트하였습니다.

## 📝 리뷰 노트

- URLComponents로 추가한 author 정보가 유지되지 않는 것 같아 우선 resourceName에 author 정보를 추가하여 전송 후 파싱하여 사용합니다.
- Date의 경우 메타데이터가 올바른 파일이라면 (시뮬레이터 x, 아이클라우드에만 있는 동영상 파일x) 날짜가 정상적으로 표시됩니다. (실제 디바이스로 테스트 해보니 잘 되었습니다.)
- Video + SharedVideo를 병합하려고 했으나 둘의 역할이 달라 기존 형태를 유지하게 두었습니다.
- 자신이 올린 동영상은 "사용자"로 표시됩니다. (VideoListItem에서만 그런 것이고 sharedVideo로는 자신의 정보가 정상적으로 들어갑니다.)

## 📱 스크린샷(선택)

https://github.com/user-attachments/assets/8809e3b5-08e8-4bb9-baca-954846cc2d99


