### PR TITLE
[Feature/#82] 순서 변경 및 길이 편집 로직 보완 및 UI연결

### DIFF
--- a/Data/Data/Element/EditVideoElement.swift
+++ b/Data/Data/Element/EditVideoElement.swift
@@ -18,14 +18,12 @@ struct EditVideoElement: Codable, Hashable {
     let endTime: Double
 
     func hash(into hasher: inout Hasher) {
-//        hasher.combine(url.lastPathComponent)
         hasher.combine(name)
     }
 
     static func == (lhs: EditVideoElement, rhs: EditVideoElement) -> Bool {
         return lhs.name == rhs.name
     }
-    // lhs.url.lastPathComponent == rhs.url.lastPathComponent &&
 }
 
 struct User: Codable, Hashable {

--- a/Domain/UseCase/VideoUseCase.swift
+++ b/Domain/UseCase/VideoUseCase.swift
@@ -139,10 +139,11 @@ private extension VideoUseCase {
         let video = editingVideos.remove(at: oldIndex)
         editingVideos.insert(video, at: index)
         
-        let newVideos = editingVideos.enumerated().map { (index, video) in
+        let listIndexOrderedVideo = editingVideos.enumerated().map { (index, video) in
             updatedVideo(video: video, index: index)
         }
-
+        
+        editingVideos = listIndexOrderedVideo
         return newVideos
     }
     

--- a/Domain/UseCase/VideoUseCase.swift
+++ b/Domain/UseCase/VideoUseCase.swift
@@ -108,9 +108,7 @@ private extension VideoUseCase {
         
         editVideoRepository.editedVideos
             .sink(with: self) { (owner, videos) in
-                print(videos)
                 owner.editingVideos = videos
-//                videos.forEach {  owner.editingVideos[$0.url.path] = $0 }
                 owner.editedVideos.send(videos)
             }
             .store(in: &cancellables)

--- a/Domain/UseCase/VideoUseCase.swift
+++ b/Domain/UseCase/VideoUseCase.swift
@@ -15,7 +15,7 @@ import Interfaces
 public final class VideoUseCase {
 	private var cancellables: Set<AnyCancellable> = []
 	private var sharedVideos: [SharedVideo] = []
-    private var editingVideos = [String: Video]()
+    private var editingVideos = [Video]()
 	private let sharingVideoRepository: SharingVideoRepositoryInterface
     private let editVideoRepository: EditVideoRepositoryInterface
 
@@ -61,7 +61,7 @@ extension VideoUseCase: EditVideoUseCaseInterface {
     public func fetchVideos() async -> [Video] {
         var videos = [Video]()
         let sortedVideos = sharedVideos
-            .sorted { $0.localUrl.path < $1.localUrl.path }
+            .sorted { $0.localUrl.lastPathComponent < $1.localUrl.lastPathComponent }
         
         for (index, video) in sortedVideos.enumerated() {
             let duration = await duration(url: video.localUrl)
@@ -76,8 +76,8 @@ extension VideoUseCase: EditVideoUseCaseInterface {
             videos.append(video)
         }
         
-        videos.forEach { editingVideos[$0.url.path] = $0 }
         editVideoRepository.initializedVideo(videos)
+        editingVideos = videos
         return videos
     }
     
@@ -87,7 +87,7 @@ extension VideoUseCase: EditVideoUseCaseInterface {
     }
     
     public func reArrangingVideo(url: URL, index: Int) {
-        let videos = updatedVideos(url: url, index: index)
+        let videos = updatedVideos(url: url, to: index)
         editVideoRepository.reArrangingVideo(videos)
     }
 }
@@ -107,12 +107,18 @@ private extension VideoUseCase {
 			.store(in: &cancellables)
         
         editVideoRepository.editedVideos
-            .subscribe(editedVideos)
+            .sink(with: self) { (owner, videos) in
+                print(videos)
+                owner.editingVideos = videos
+//                videos.forEach {  owner.editingVideos[$0.url.path] = $0 }
+                owner.editedVideos.send(videos)
+            }
             .store(in: &cancellables)
 	}
     
     func updatedVideo(url: URL, startTime: Double, endTime: Double) -> Video? {
-        guard let video = editingVideos[url.path] else { return nil }
+        guard let video = editingVideos.first(where: { $0.url.path == url.path })
+        else { return nil }
                 
         let newVideo = Video(
             url: video.url,
@@ -125,28 +131,20 @@ private extension VideoUseCase {
             endTime: endTime
         )
         
-        editingVideos[url.path] = video
-        
         return newVideo
     }
     
-    func updatedVideos(url: URL, index: Int) -> [Video] {
-        guard let video = editingVideos[url.path] else { return [] }
-        var newVideos = [Video]()
-        let beforeIndex = video.index
-        let adder = beforeIndex < index ? -1 : 1
-        
-        let lowerBound = min(beforeIndex, index)
-        let upperBound = min(beforeIndex, index)
-        
-        let videos = editingVideos.values
-            .filter { $0.index >= lowerBound && $0.index < upperBound }
-            .map { updatedVideo(video: $0, index: index + adder) }
+    func updatedVideos(url: URL, to index: Int) -> [Video] {
+        guard let oldIndex = editingVideos.firstIndex(where: { $0.url.lastPathComponent == url.lastPathComponent })
+        else { return editingVideos }
 
-        newVideos.append(contentsOf: videos)
-        newVideos.append(updatedVideo(video: video, index: index))
-        newVideos.forEach { editingVideos[$0.url.path] = $0 }
+        let video = editingVideos.remove(at: oldIndex)
+        editingVideos.insert(video, at: index)
         
+        let newVideos = editingVideos.enumerated().map { (index, video) in
+            updatedVideo(video: video, index: index)
+        }
+
         return newVideos
     }
     
@@ -154,7 +152,7 @@ private extension VideoUseCase {
         return Video(
             url: video.url,
             name: video.name,
-            index: video.index,
+            index: index,
             duration: video.duration,
             author: video.author,
             editor: video.editor,

--- a/Feature/Feature/PresentationModel/VideoPresentationModel.swift
+++ b/Feature/Feature/PresentationModel/VideoPresentationModel.swift
@@ -16,3 +16,10 @@ struct VideoPresentationModel {
 	let endTime: Double
 	let frameImage: UIImageWrapper
 }
+
+extension VideoPresentationModel: Equatable {
+    static func == (lhs: VideoPresentationModel, rhs: VideoPresentationModel) -> Bool {
+        if lhs.url == rhs.url { return true }
+        return false
+    }
+}

--- a/Feature/Feature/SharedVideoEditView/SharedVideoEditViewController.swift
+++ b/Feature/Feature/SharedVideoEditView/SharedVideoEditViewController.swift
@@ -458,19 +458,20 @@ extension SharedVideoEditViewController: UICollectionViewDropDelegate {
         var updatedItems = currentItems
         updatedItems.insert(contentsOf: draggedItems, at: targetIndex)
 
+        coordinator.items.forEach { item in
+            coordinator.drop(item.dragItem, toItemAt: destinationIndexPath)
+        }
+        
         applySnapShot(with: updatedItems)
         
-        guard let reorderItem = videoTimelineDataSource.itemIdentifier(for: destinationIndexPath) else { return }
-
         collectionView.scrollToItem(
             at: destinationIndexPath,
             at: .centeredHorizontally,
             animated: true
         )
         
-        coordinator.items.forEach { item in
-            coordinator.drop(item.dragItem, toItemAt: destinationIndexPath)
-        }
+        guard let reorderItem = videoTimelineDataSource.itemIdentifier(for: destinationIndexPath) else { return }
+
         input.send(.timelineCellOrderDidChanged(to: targetIndex, url: reorderItem.url))
     }
 }

--- a/Feature/Feature/SharedVideoEditView/SharedVideoEditViewController.swift
+++ b/Feature/Feature/SharedVideoEditView/SharedVideoEditViewController.swift
@@ -453,14 +453,24 @@ extension SharedVideoEditViewController: UICollectionViewDropDelegate {
 
         snapshot.deleteItems(draggedItems)
         let targetIndex = destinationIndexPath.item
+        
         let currentItems = snapshot.itemIdentifiers
         var updatedItems = currentItems
         updatedItems.insert(contentsOf: draggedItems, at: targetIndex)
-        
-        applySnapShot(with: updatedItems)
 
+        applySnapShot(with: updatedItems)
+        
+        guard let reorderItem = videoTimelineDataSource.itemIdentifier(for: destinationIndexPath) else { return }
+
+        collectionView.scrollToItem(
+            at: destinationIndexPath,
+            at: .centeredHorizontally,
+            animated: true
+        )
+        
         coordinator.items.forEach { item in
             coordinator.drop(item.dragItem, toItemAt: destinationIndexPath)
         }
+        input.send(.timelineCellOrderDidChanged(to: targetIndex, url: reorderItem.url))
     }
 }

--- a/Feature/Feature/SharedVideoEditView/ViewModel/SharedVideoEditViewInput.swift
+++ b/Feature/Feature/SharedVideoEditView/ViewModel/SharedVideoEditViewInput.swift
@@ -13,4 +13,5 @@ enum SharedVideoEditViewInput {
     case sliderModelLowerValueDidChanged(value: Double)
     case sliderModelUpperValueDidChanged(value: Double)
     case sliderEditSaveButtonDidTapped
+    case timelineCellOrderDidChanged(to: Int, url: URL)
 }

--- a/Feature/Feature/SharedVideoEditView/ViewModel/SharedVideoEditViewModel.swift
+++ b/Feature/Feature/SharedVideoEditView/ViewModel/SharedVideoEditViewModel.swift
@@ -43,7 +43,11 @@ extension SharedVideoEditViewModel {
                 owner.updateTappedVideoPresentationModel(upperValue: value)
             case .sliderEditSaveButtonDidTapped:
                 guard let currentTappedVideoPresentationModel = owner.tappedVideoPresentationModel else { return }
-
+                if let index = owner.videoPresentationModels.firstIndex(where: {
+                    $0 == currentTappedVideoPresentationModel
+                }) {
+                    owner.videoPresentationModels[index] = currentTappedVideoPresentationModel
+                }
                 owner.usecase.trimmingVideo(
                     url: currentTappedVideoPresentationModel.url,
                     startTime: currentTappedVideoPresentationModel.startTime,

--- a/Feature/Feature/SharedVideoEditView/ViewModel/SharedVideoEditViewModel.swift
+++ b/Feature/Feature/SharedVideoEditView/ViewModel/SharedVideoEditViewModel.swift
@@ -75,7 +75,7 @@ private extension SharedVideoEditViewModel {
                     if let currentTappedVideoPresentationModel = owner.tappedVideoPresentationModel {
                         guard
                             let tappedVideo = videos.first(
-                                where: { $0.url == currentTappedVideoPresentationModel.url }),
+                                where: { $0.url.path == currentTappedVideoPresentationModel.url.path }),
                             let model = await owner.makeVideoPresentationModel(video: tappedVideo)
                         else { return }
                         owner.setTappedVideoPresentationModel(model: model)


### PR DESCRIPTION
## 관련 이슈

- #82 

## ✅ 완료 및 수정 내역

- 순서 변경 및 길이 편집 로직 보완 및 UI연결

## 🛠️ 테스트 방법

- 직접 실행하여 테스트 가능합니다.

## 📝 리뷰 노트

- 딕셔너리로 관리하던 동영상이 인덱스가 계속 달라지는 현상이 있어 부득이하게 리스트로 관리하게 됐습니다.
- 순서 변경 시 드랍하는 셀로 화면이 이동하도록 애니메이션을 추가했습니다.

장원영님 마무리 부탁드리겠슴니다

## 📱 스크린샷(선택)
- 순서변경

https://github.com/user-attachments/assets/764a7aad-607b-48f7-a6a0-0bb7487db197 

- 길이편집

https://github.com/user-attachments/assets/b1a2f8dd-a67c-4ad4-b40c-d591cfe8eb30 

