### PR TITLE
[Feature/#92] 프리뷰 화면 구현 및 비디오 저장 로직 확인

### DIFF
--- a/App/App/Info.plist
+++ b/App/App/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>동영상을 갤러리에 저장하기 위해 권한이 필요합니다.</string>
 	<key>UIUserInterfaceStyle</key>
 	<string>Dark</string>
 	<key>CFBundleDisplayName</key>

--- a/App/App/SceneDelegate.swift
+++ b/App/App/SceneDelegate.swift
@@ -136,5 +136,10 @@ extension SceneDelegate {
                 usecase: DIContainer.shared.resolve(type: EditVideoUseCaseInterface.self)
             )
         )
+        
+        DIContainer.shared.register(
+            type: PreviewViewModel.self,
+            instance: PreviewViewModel(usecase: DIContainer.shared.resolve(type: EditVideoUseCaseInterface.self))
+        )
     }
 }

--- a/Data/Data/SharingVideoRepository.swift
+++ b/Data/Data/SharingVideoRepository.swift
@@ -29,6 +29,7 @@ public final class SharingVideoRepository: SharingVideoRepositoryInterface {
     
     public let updatedSharedVideo = PassthroughSubject<SharedVideo, Never>()
     public let isSynchronized = PassthroughSubject<Void, Never>()
+    public let startSynchronize = PassthroughSubject<Void, Never>()
     
     public init(socketProvider: SharingVideoSocketProvidable) {
         self.socketProvider = socketProvider
@@ -45,6 +46,7 @@ public final class SharingVideoRepository: SharingVideoRepositoryInterface {
                 guard let data = try? JSONDecoder().decode(SyncMessage.self, from: data) else { return }
                 switch data {
                     case .hash(let hashes):
+                        startSynchronize.send(())
                         sendComparingResult(with: hashes, to: peerID.id)
                     case .hashMatch(let result):
                         synchronize(with: result, to: peerID.id)

--- a/Domain/Interfaces/RepositoryInterface/SharingVideoRepositoryInterface.swift
+++ b/Domain/Interfaces/RepositoryInterface/SharingVideoRepositoryInterface.swift
@@ -12,6 +12,7 @@ import Foundation
 public protocol SharingVideoRepositoryInterface {
     var updatedSharedVideo: PassthroughSubject<SharedVideo, Never> { get }
     var isSynchronized: PassthroughSubject<Void, Never> { get }
+    var startSynchronize: PassthroughSubject<Void, Never> { get }
 
     func shareVideo(url: URL, resourceName: String)
     func broadcastHashes()

--- a/Domain/Interfaces/UseCaseInterface/EditVideoUseCaseInterface.swift
+++ b/Domain/Interfaces/UseCaseInterface/EditVideoUseCaseInterface.swift
@@ -11,6 +11,7 @@ import Foundation
 
 public protocol EditVideoUseCaseInterface {
     var editedVideos: PassthroughSubject<[Video], Never> { get }
+    var videos: [Video] { get }
     
     func fetchVideos() async -> [Video]
     

--- a/Domain/Interfaces/UseCaseInterface/SharingVideoUseCaseInterface.swift
+++ b/Domain/Interfaces/UseCaseInterface/SharingVideoUseCaseInterface.swift
@@ -12,6 +12,7 @@ import Foundation
 public protocol SharingVideoUseCaseInterface {
     var updatedSharedVideo: PassthroughSubject<SharedVideo, Never> { get }
     var isSynchronized: PassthroughSubject<Void, Never> { get }
+    var startSynchronize: PassthroughSubject<Void, Never> { get }
     
     func fetchVideos() -> [SharedVideo]
     func shareVideo(_ url: URL, resourceName: String)

--- a/Domain/UseCase/VideoUseCase.swift
+++ b/Domain/UseCase/VideoUseCase.swift
@@ -20,6 +20,7 @@ public final class VideoUseCase {
     private let editVideoRepository: EditVideoRepositoryInterface
 
 	public let isSynchronized = PassthroughSubject<Void, Never>()
+    public let startSynchronize = PassthroughSubject<Void, Never>()
     public let updatedSharedVideo = PassthroughSubject<SharedVideo, Never>()
     public let editedVideos = PassthroughSubject<[Video], Never>()
 	
@@ -105,6 +106,10 @@ private extension VideoUseCase {
 		sharingVideoRepository.isSynchronized
 			.subscribe(isSynchronized)
 			.store(in: &cancellables)
+        
+        sharingVideoRepository.startSynchronize
+            .subscribe(startSynchronize)
+            .store(in: &cancellables)
         
         editVideoRepository.editedVideos
             .sink(with: self) { owner, videos in

--- a/Domain/UseCase/VideoUseCase.swift
+++ b/Domain/UseCase/VideoUseCase.swift
@@ -23,6 +23,10 @@ public final class VideoUseCase {
     public let startSynchronize = PassthroughSubject<Void, Never>()
     public let updatedSharedVideo = PassthroughSubject<SharedVideo, Never>()
     public let editedVideos = PassthroughSubject<[Video], Never>()
+    
+    public var videos: [Video] {
+        editingVideos.values.sorted(by: { $0.index < $1.index })
+    }
 	
     public init(
         sharingVideoRepository: SharingVideoRepositoryInterface,

--- a/Domain/UseCase/VideoUseCase.swift
+++ b/Domain/UseCase/VideoUseCase.swift
@@ -107,9 +107,18 @@ private extension VideoUseCase {
 			.store(in: &cancellables)
         
         editVideoRepository.editedVideos
-            .subscribe(editedVideos)
+            .sink(with: self) { owner, videos in
+                owner.updateEditingVideos(videos)
+                owner.editedVideos.send(videos)
+            }
             .store(in: &cancellables)
 	}
+    
+    func updateEditingVideos(_ videos: [Video]) {
+        videos.forEach {
+            editingVideos[$0.url.path] = $0
+        }
+    }
     
     func updatedVideo(url: URL, startTime: Double, endTime: Double) -> Video? {
         guard let video = editingVideos[url.path] else { return nil }

--- a/Feature/Feature.xcodeproj/project.pbxproj
+++ b/Feature/Feature.xcodeproj/project.pbxproj
@@ -34,7 +34,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		FE8208012CED782500307694 /* Exceptions for "Feature" folder in "Feature" target */ = {
+		D95A3B062D01D7500007A71A /* Exceptions for "Feature" folder in "Feature" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				ConnectionView/ConnectionViewController.swift,
@@ -57,6 +57,7 @@
 				Helper/EventPublisher.swift,
 				Helper/RoundButton.swift,
 				"Helper/Sequence+AsyncCompactMap.swift",
+				Helper/Toast.swift,
 				"Helper/UIAlertController+Types.swift",
 				"Helper/UIColor+HexInitialization.swift",
 				"Helper/UIImage+Concat.swift",
@@ -65,6 +66,11 @@
 				"Helper/UIView+Extension.swift",
 				MainViewController.swift,
 				PresentationModel/VideoPresentationModel.swift,
+				PreviewView/PreviewViewController.swift,
+				PreviewView/ViewModel/PreviewViewInput.swift,
+				PreviewView/ViewModel/PreviewViewModel.swift,
+				PreviewView/ViewModel/PreviewViewOutput.swift,
+				ResultView/ResultViewController.swift,
 				SharedVideoEditView/SharedVideoEditViewController.swift,
 				SharedVideoEditView/VideoMerger/VideoMerger.swift,
 				SharedVideoEditView/View/CollectionView/VideoTimelineCollectionViewCell.swift,
@@ -102,10 +108,10 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		FE6EF3F12CD8B71E005DC39D /* Feature */ = {
+		D95A3AC62D01D7500007A71A /* Feature */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
-				FE8208012CED782500307694 /* Exceptions for "Feature" folder in "Feature" target */,
+				D95A3B062D01D7500007A71A /* Exceptions for "Feature" folder in "Feature" target */,
 			);
 			path = Feature;
 			sourceTree = "<group>";
@@ -130,7 +136,7 @@
 		FE6EF3E62CD8B71E005DC39D = {
 			isa = PBXGroup;
 			children = (
-				FE6EF3F12CD8B71E005DC39D /* Feature */,
+				D95A3AC62D01D7500007A71A /* Feature */,
 				FE6EF4272CD8B843005DC39D /* Frameworks */,
 				FE6EF3F02CD8B71E005DC39D /* Products */,
 			);

--- a/Feature/Feature/Helper/Toast.swift
+++ b/Feature/Feature/Helper/Toast.swift
@@ -1,0 +1,56 @@
+//
+//  Toast.swift
+//  Feature
+//
+//  Created by 디해 on 12/5/24.
+//
+
+import UIKit
+
+extension UIView {
+    private static let toastTag = 9999
+    
+    func showToast(message: String, duration: TimeInterval? = nil) {
+        if let existingToast = self.viewWithTag(UIView.toastTag) {
+            existingToast.removeFromSuperview()
+        }
+        
+        let toastLabel = UILabel()
+        toastLabel.text = message
+        toastLabel.textColor = .white
+        toastLabel.backgroundColor = UIColor.black.withAlphaComponent(0.8)
+        toastLabel.textAlignment = .center
+        toastLabel.font = UIFont.systemFont(ofSize: 15)
+        toastLabel.numberOfLines = 0
+        toastLabel.tag = UIView.toastTag
+        
+        let maxSize = CGSize(width: self.bounds.width - 40, height: self.bounds.height)
+        let textSize = toastLabel.sizeThatFits(maxSize)
+        toastLabel.frame = CGRect(
+            x: (self.bounds.width - textSize.width - 20) / 2,
+            y: self.bounds.height / 2 - textSize.height / 2,
+            width: textSize.width + 40,
+            height: textSize.height + 40
+        )
+        toastLabel.layer.cornerRadius = 20
+        toastLabel.layer.masksToBounds = true
+        
+        self.addSubview(toastLabel)
+        
+        if let duration = duration {
+            DispatchQueue.main.asyncAfter(deadline: .now() + duration) { [weak self] in
+                self?.hideToast()
+            }
+        }
+    }
+    
+    func hideToast() {
+        if let toastLabel = self.viewWithTag(UIView.toastTag) {
+            UIView.animate(withDuration: 0.5, animations: {
+                toastLabel.alpha = 0.0
+            }) { _ in
+                toastLabel.removeFromSuperview()
+            }
+        }
+    }
+}

--- a/Feature/Feature/PreviewView/PreviewViewController.swift
+++ b/Feature/Feature/PreviewView/PreviewViewController.swift
@@ -1,0 +1,122 @@
+//
+//  ResultViewController.swift
+//  Feature
+//
+//  Created by 디해 on 12/5/24.
+//
+
+import AVFoundation
+import Combine
+import UIKit
+
+public final class PreviewViewController: UIViewController {
+    private let videoView = VideoPlayerView()
+    private let saveButton = UIButton(type: .system)
+    
+    private let viewModel: PreviewViewModel
+    private let input = PassthroughSubject<PreviewViewInput, Never>()
+    var cancellables = Set<AnyCancellable>()
+    
+    public init(viewModel: PreviewViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setupUI()
+        setupViewModelBinding()
+        setupUIBinding()
+    }
+    
+    public override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        input.send(.loadPreview(size: videoView.frame.size))
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Binding
+private extension PreviewViewController {
+    func setupViewModelBinding() {
+        let output = viewModel.transform(input.eraseToAnyPublisher())
+        
+        output.receive(on: DispatchQueue.main)
+            .sink(with: self) { (owner, output) in
+                switch output {
+                case .loadedPreview(let playerItem):
+                    owner.videoView.replaceVideo(playerItem: playerItem)
+                case .videoSaved:
+                    owner.navigateToResult()
+                }
+            }
+            .store(in: &cancellables)
+    }
+    
+    func setupUIBinding() {
+        saveButton.bs.tap
+            .sink(with: self) { owner, _ in
+                owner.input.send(.saveVideo)
+            }
+            .store(in: &cancellables)
+    }
+}
+
+// MARK: - UI Configure
+private extension PreviewViewController {
+    func setupUI() {
+        setupViewAttributes()
+        setupViewHierarchies()
+        setupViewConstraints()
+    }
+    
+    func setupViewAttributes() {
+        view.backgroundColor = .black
+        setupSaveButton()
+    }
+    
+    func setupSaveButton() {
+        saveButton.backgroundColor = .white
+        saveButton.setTitle("저장", for: .normal)
+        saveButton.setTitleColor(.black, for: .normal)
+        saveButton.titleLabel?.font = .systemFont(ofSize: 20)
+        saveButton.layer.cornerRadius = 25
+    }
+    
+    func setupViewHierarchies() {
+        view.addSubviews(
+            videoView,
+            saveButton
+        )
+    }
+    
+    func setupViewConstraints() {
+        videoView.snp.makeConstraints { make in
+            make.top.equalToSuperview()
+            make.horizontalEdges.equalToSuperview()
+            make.height.equalTo(550)
+        }
+        
+        saveButton.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(videoView.snp.bottom).offset(30)
+            make.width.equalTo(160)
+            make.height.equalTo(50)
+        }
+    }
+}
+
+// MARK: - Private Methods
+private extension PreviewViewController {
+    func navigateToResult() {
+        let resultViewController = ResultViewController()
+        
+        navigationController?.pushViewController(resultViewController, animated: true)
+    }
+}

--- a/Feature/Feature/PreviewView/ViewModel/PreviewViewInput.swift
+++ b/Feature/Feature/PreviewView/ViewModel/PreviewViewInput.swift
@@ -1,0 +1,15 @@
+//
+//  ResultViewInput.swift
+//  Feature
+//
+//  Created by 디해 on 12/5/24.
+//
+
+import Foundation
+
+// MARK: - Input
+
+enum PreviewViewInput {
+    case loadPreview(size: CGSize)
+    case saveVideo
+}

--- a/Feature/Feature/PreviewView/ViewModel/PreviewViewModel.swift
+++ b/Feature/Feature/PreviewView/ViewModel/PreviewViewModel.swift
@@ -1,0 +1,63 @@
+//
+//  ResultViewModel.swift
+//  Feature
+//
+//  Created by 디해 on 12/5/24.
+//
+
+import Combine
+import Core
+import Foundation
+import Photos
+import Interfaces
+
+public final class PreviewViewModel {
+    typealias Input = PreviewViewInput
+    typealias Output = PreviewViewOutput
+    
+    var output = PassthroughSubject<Output, Never>()
+    var cancellables: Set<AnyCancellable> = []
+    
+    private let usecase: EditVideoUseCaseInterface
+    
+    public init(usecase: EditVideoUseCaseInterface) {
+        self.usecase = usecase
+    }
+    
+    func transform(_ input: AnyPublisher<PreviewViewInput, Never>) -> AnyPublisher<PreviewViewOutput, Never> {
+        input.sink(with: self) { owner, input in
+            switch input {
+            case .loadPreview(let size):
+                Task {
+                    let videos = owner.usecase.videos
+                    guard let preview = try? await VideoMerger.preview(videos: videos, size: size) else { return }
+                    owner.output.send(.loadedPreview(playerItem: preview))
+                }
+                
+            case .saveVideo:
+                Task { @MainActor in
+                    let outputURL = FileSystemManager.shared.folder
+                        .appending(path: UUID().uuidString)
+                        .appendingPathExtension("mp4")
+                    let videos = owner.usecase.videos
+                    try? await VideoMerger.mergeWithSave(videos, outputURL: outputURL)
+                    
+                    PHPhotoLibrary.requestAuthorization { status in
+                        guard status == .authorized else { return }
+                    }
+                    
+                    PHPhotoLibrary.shared().performChanges({
+                        PHAssetChangeRequest.creationRequestForAssetFromVideo(atFileURL: outputURL)
+                    }) { success, _ in
+                        if success {
+                            owner.output.send(.videoSaved)
+                        }
+                    }
+                }
+            }
+        }
+        .store(in: &cancellables)
+        
+        return output.eraseToAnyPublisher()
+    }
+}

--- a/Feature/Feature/PreviewView/ViewModel/PreviewViewOutput.swift
+++ b/Feature/Feature/PreviewView/ViewModel/PreviewViewOutput.swift
@@ -1,0 +1,16 @@
+//
+//  ResultViewOutput.swift
+//  Feature
+//
+//  Created by 디해 on 12/5/24.
+//
+
+import AVFoundation
+import Foundation
+
+// MARK: - Output
+
+enum PreviewViewOutput {
+    case loadedPreview(playerItem: AVPlayerItem)
+    case videoSaved
+}

--- a/Feature/Feature/ResultView/ResultViewController.swift
+++ b/Feature/Feature/ResultView/ResultViewController.swift
@@ -1,0 +1,45 @@
+//
+//  ResultViewController.swift
+//  Feature
+//
+//  Created by 디해 on 12/6/24.
+//
+
+import UIKit
+
+public final class ResultViewController: UIViewController {
+    private let mainLabel = UILabel()
+    
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        setupViewAttributes()
+        setupViewHierarchies()
+        setupViewConstraints()
+        setupMainLabel()
+    }
+}
+
+// MARK: - Setting
+private extension ResultViewController {
+    func setupViewAttributes() {
+        view.backgroundColor = UIColor.black
+    }
+    
+    func setupViewHierarchies() {
+        view.addSubview(mainLabel)
+    }
+    
+    func setupViewConstraints() {
+        mainLabel.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+        }
+    }
+    
+    func setupMainLabel() {
+        mainLabel.text = "성공적으로\n동영상을 저장했어요! 🥳"
+        mainLabel.font = UIFont.boldSystemFont(ofSize: 20)
+        mainLabel.textColor = .white
+        mainLabel.numberOfLines = 0
+        mainLabel.textAlignment = .center
+    }
+}

--- a/Feature/Feature/SharedVideoEditView/SharedVideoEditViewController.swift
+++ b/Feature/Feature/SharedVideoEditView/SharedVideoEditViewController.swift
@@ -61,6 +61,11 @@ public final class SharedVideoEditViewController: UIViewController {
         
         input.send(.viewDidLoad)
     }
+    
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: true)
+    }
 }
 
 // MARK: - Binding
@@ -105,6 +110,12 @@ private extension SharedVideoEditViewController {
 				owner.presentCancelAlertViewController()
 			}
 			.store(in: &cancellables)
+        
+        nextButton.bs.tap
+            .sink(with: self) { owner, _ in
+                owner.navigateToPreview()
+            }
+            .store(in: &cancellables)
 	}
 }
 
@@ -389,6 +400,13 @@ private extension SharedVideoEditViewController {
                 .cancel()]
         ), animated: true)
 	}
+    
+    func navigateToPreview() {
+        let previewViewController = PreviewViewController(
+            viewModel: DIContainer.shared.resolve(type: PreviewViewModel.self)
+        )
+        navigationController?.pushViewController(previewViewController, animated: true)
+    }
 }
 
 // MARK: - UICollectionViewDelegate

--- a/Feature/Feature/SharedVideoEditView/VideoMerger/VideoMerger.swift
+++ b/Feature/Feature/SharedVideoEditView/VideoMerger/VideoMerger.swift
@@ -99,6 +99,10 @@ enum VideoMerger {
         videoComposition.frameDuration = CMTime(value: 1, timescale: frameRate)
         videoComposition.renderSize = resultSize
         videoComposition.instructions =  layerInstructions
+        //hdr무시
+        videoComposition.colorPrimaries = AVVideoColorPrimaries_ITU_R_709_2
+        videoComposition.colorTransferFunction = AVVideoTransferFunction_ITU_R_709_2
+        videoComposition.colorYCbCrMatrix = AVVideoYCbCrMatrix_ITU_R_709_2
         
         return (composition, videoComposition)
     }

--- a/Feature/Feature/SharedVideoEditView/View/VideoPlayer/VideoPlayerView.swift
+++ b/Feature/Feature/SharedVideoEditView/View/VideoPlayer/VideoPlayerView.swift
@@ -63,6 +63,12 @@ extension VideoPlayerView {
     }
 
     func replaceVideo(playerItem: AVPlayerItem) {
+        //hdr무시
+        let videoComposition = AVMutableVideoComposition(propertiesOf: playerItem.asset)
+        videoComposition.colorPrimaries = AVVideoColorPrimaries_ITU_R_709_2
+        videoComposition.colorTransferFunction = AVVideoTransferFunction_ITU_R_709_2
+        videoComposition.colorYCbCrMatrix = AVVideoYCbCrMatrix_ITU_R_709_2
+        playerItem.videoComposition = videoComposition
         player.pause()
         player.replaceCurrentItem(with: playerItem)
     }

--- a/Feature/Feature/VideoListView/VideoListViewController.swift
+++ b/Feature/Feature/VideoListView/VideoListViewController.swift
@@ -102,7 +102,10 @@ private extension VideoListViewController {
                 case .videoListDidChanged(let videos):
                     self?.items = videos
                 case .readyForNextScreen:
+                    self?.view.hideToast()
                     self?.navigateToEditor()
+                case .startSynchronize:
+                    self?.pause()
                 }
             }
             .store(in: &cancellables)
@@ -118,6 +121,7 @@ private extension VideoListViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.input.send(.validateSynchronization)
+                self?.pause()
             }
             .store(in: &cancellables)
     }
@@ -194,6 +198,11 @@ private extension VideoListViewController {
             viewModel: DIContainer.shared.resolve(type: SharedVideoEditViewModel.self)
         )
         navigationController?.pushViewController(sharedVideoEditViewController, animated: true)
+    }
+    
+    func pause() {
+        view.showToast(message: "동기화 중입니다...")
+        nextButton.isEnabled = false
     }
 }
 

--- a/Feature/Feature/VideoListView/ViewModel/MultipeerVideoListViewModel.swift
+++ b/Feature/Feature/VideoListView/ViewModel/MultipeerVideoListViewModel.swift
@@ -41,6 +41,13 @@ private extension MultipeerVideoListViewModel {
                 output.send(.readyForNextScreen)
             }
             .store(in: &cancellables)
+        
+        usecase.startSynchronize
+            .sink { [weak self] _ in
+                guard let self else { return }
+                output.send(.startSynchronize)
+            }
+            .store(in: &cancellables)
     }
 }
 

--- a/Feature/Feature/VideoListView/ViewModel/VideoListViewOutput.swift
+++ b/Feature/Feature/VideoListView/ViewModel/VideoListViewOutput.swift
@@ -10,4 +10,5 @@ import Foundation
 public enum VideoListViewOutput {
     case videoListDidChanged(videos: [VideoListItem])
     case readyForNextScreen
+    case startSynchronize
 }


### PR DESCRIPTION
## 관련 이슈

- #92 

## ✅ 완료 및 수정 내역

- Preview 화면 구현
- VideoMerger 에러 수정

## 🛠️ 테스트 방법

- 첫 화면부터 연결하여 테스트 하였습니다.

## 📝 리뷰 노트

- VideoMerger 수정
NaturalSize에서 정확한 값을 얻어오지 않아 윤회님이 주신 코드 참조하여 수정하였습니다. (감사합니다!)
- 종료 화면
정상적으로 저장이 완료되었을 때만 넘어갑니다.

## 📱 스크린샷(선택)

https://github.com/user-attachments/assets/3832400e-489c-4f28-aa63-c5251ec90621



